### PR TITLE
build: use minified file as main on production builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -149,7 +149,7 @@ module.exports = function(options) {
   var mainFile =
     options.platform === "vue"
       ? "survey-vue.js"
-      : "survey." + options.platformPrefix + ".js";
+      : "survey." + options.platformPrefix + (options.buildType === "prod" ? ".min" : "") + ".js";
   var packagePlatformJson = {
     name: "survey-" + options.platform,
     version: packageJson.version,


### PR DESCRIPTION
With this change, when creating production builds, the `package.json` file will load the minified version instead of the full version. This saves **~2.4mb** on production, which is critical to page load times.

I did not update the vue build, since it appears to be broken regardless.