### PR TITLE
Fixed Japanese localization progressText so that it correctly displays

### DIFF
--- a/src/localization/japanese.ts
+++ b/src/localization/japanese.ts
@@ -9,7 +9,7 @@ export var japaneseSurveyStrings = {
   otherItemText: "その他（説明）",
   noneItemText: "なし",
   selectAllItemText: "すべて選択",
-  progressText: "{０}/{1}頁",
+  progressText: "{0}/{1}頁",
   emptySurvey: "この調査に表示できるページや質問はありません",
   completingSurvey: "調査を完了してくれてありがとうございました",
   loadingSurvey: "調査をダウンロード中",


### PR DESCRIPTION
In the Japanese localization the progressText does not display correctly. This PR makes a simple change so that the page number actually gets shown.