### PR TITLE
Add click handler to cell in matrix questions

### DIFF
--- a/src/vue/matrix.vue
+++ b/src/vue/matrix.vue
@@ -14,7 +14,7 @@
                     <td v-if="question.hasCellText" v-for="(column, columnIndex) in question.visibleColumns" :class="getItemClass(row, column)" v-on:click="function() { cellClick(row, column); }">
                         <span>{{question.getCellDisplayLocText(row.name, column).renderedHtml}}</span>
                     </td>
-                    <td v-if="!question.hasCellText" v-for="(column, columnIndex) in question.visibleColumns" :headers="column.locText.renderedHtml">
+                    <td v-if="!question.hasCellText" v-for="(column, columnIndex) in question.visibleColumns" :headers="column.locText.renderedHtml" v-on:click="function() { cellClick(row, column); }">
                         <label :class="getItemClass(row, column)">
                             <input type="radio" :class="question.cssClasses.itemValue" :name="row.fullName" v-model="row.value" :value="column.value" :disabled="question.isReadOnly" :id="question.inputId + '_' + row.name + '_' + columnIndex" v-bind:aria-required="question.isRequired" :aria-label="question.locTitle.renderedHtml"/>
                             <span class="circle"></span>

--- a/src/vue/matrix.vue
+++ b/src/vue/matrix.vue
@@ -14,7 +14,7 @@
                     <td v-if="question.hasCellText" v-for="(column, columnIndex) in question.visibleColumns" :class="getItemClass(row, column)" v-on:click="function() { cellClick(row, column); }">
                         <span>{{question.getCellDisplayLocText(row.name, column).renderedHtml}}</span>
                     </td>
-                    <td v-if="!question.hasCellText" v-for="(column, columnIndex) in question.visibleColumns" :headers="column.locText.renderedHtml" v-on:click="function() { cellClick(row, column); }">
+                    <td v-if="!question.hasCellText" v-for="(column, columnIndex) in question.visibleColumns" :headers="column.locText.renderedHtml" :class="getItemClass(row, column)" v-on:click="function() { cellClick(row, column); }">
                         <label :class="getItemClass(row, column)">
                             <input type="radio" :class="question.cssClasses.itemValue" :name="row.fullName" v-model="row.value" :value="column.value" :disabled="question.isReadOnly" :id="question.inputId + '_' + row.name + '_' + columnIndex" v-bind:aria-required="question.isRequired" :aria-label="question.locTitle.renderedHtml"/>
                             <span class="circle"></span>


### PR DESCRIPTION
Currently for cells in matrix questions a user has to click/touch on the radio button.
In mobile mode we have styled the cells to look like buttons but they only register a click on the radio button or label. A click handler on the table cell gives us the exact behaviour we need.