### PR TITLE
Add missing ':' for the value field in vue version

### DIFF
--- a/src/vue/comment.vue
+++ b/src/vue/comment.vue
@@ -4,7 +4,7 @@
       type="text"
       :readonly="question.isReadOnly"
       :disabled="question.isReadOnly"
-      value="question.value"
+      :value="question.value"
       :id="question.inputId"
       :maxlength="question.getMaxLength()"
       :cols="question.cols"


### PR DESCRIPTION
Bug: in Vue.js

Issue: Migration from v-model to value is missing the ':'.

Error: data binding fails in comment type.