### PR TITLE
Overwrite calculated values in valuesHash

### DIFF
--- a/src/survey.ts
+++ b/src/survey.ts
@@ -1959,13 +1959,13 @@ export class SurveyModel extends Base
    */
   public get data(): any {
     var result: { [index: string]: any } = {};
-    this.setCalcuatedValuesIntoResult(result);
     for (var key in this.valuesHash) {
       var dataValue = this.getDataValueCore(this.valuesHash, key);
       if (dataValue !== undefined) {
         result[key] = dataValue;
       }
     }
+    this.setCalcuatedValuesIntoResult(result);
     return result;
   }
   public set data(data: any) {


### PR DESCRIPTION
If the name of a calculated value with no dependents, but where
includeIntoResult = true, is present in the valuesHash (because it was
loaded from saved data), the old value is returned from survey.data.
This change moves the writing of calculated values to after copying
from valuesHash, so that the new result is reflected.

Fixes #2133 