### PR TITLE
Fix: header attribute value in matrixdynamic cells

### DIFF
--- a/src/react/reactquestionmatrixdropdownbase.tsx
+++ b/src/react/reactquestionmatrixdropdownbase.tsx
@@ -229,7 +229,8 @@ export class SurveyQuestionMatrixDropdownCell extends SurveyQuestionAndErrorsCel
   }
 
   protected getHeaderText(): string {
-    return !!this.cell.locTitle ? this.cell.locTitle.renderedHtml : "";
+    var column = this.cell.cell && this.cell.cell.column;
+    return !!(column && column.locTitle) ? column.locTitle.renderedHtml : "";
   }
   protected renderQuestion(): JSX.Element {
     if (!this.cell.isChoice)


### PR DESCRIPTION
# Populate matrixdynamic table cell header attribute with column title value

I have just updated `surveyjs` from `v^1.0.73` to `v^1.7.19` and we have an issue:

The header attribute value for a `matrixdynamic` table cell was not being populated with a columns title value. This meant that when a survey is viewed in small screen there is no label for an input.

This fix locates the `this.cell.cell.column.locTitle.renderedHtml` on the cells column within the `getHeaderText` method and returns it to be applied to the table cells `header` attribute.


## Screenshots
### Surveyjs v^1.0.73
#### Large screen
![Screenshot 2020-07-14 at 14 53 59](https://user-images.githubusercontent.com/2305016/87436112-81da3c80-c5e4-11ea-8f1c-dfd3450456c4.png)


#### Small screen
![Screenshot 2020-07-14 at 14 54 13](https://user-images.githubusercontent.com/2305016/87435784-1b551e80-c5e4-11ea-934b-fb50eef9e7e7.png)


### Surveyjs v^1.7.19
#### Large screen
![Screenshot 2020-07-14 at 14 54 44](https://user-images.githubusercontent.com/2305016/87435870-3162df00-c5e4-11ea-99a6-7ac152bb607d.png)

#### Small screen
![Screenshot 2020-07-14 at 14 54 33](https://user-images.githubusercontent.com/2305016/87435894-37f15680-c5e4-11ea-9965-8adc55a69026.png)

## Tests
- I have ran all tests and we are green
- I have also built the project locally and used it in our app. Everything works as expected
- I have looked around to add a test for this but cannot see any react tests around

## Of Note
### New to surveyjs
I am new to `surveyjs` and would appreciate any thoughts on this fix as I may of missed something. I am certainly seeing `this.cell.cell` around the codebase so feel this is an approach taken elsewhere.

### Example have this problem
You can also observe that the table cells `header` attribute is not being populated on [surveyjs matrixdynamic example](https://surveyjs.io/Examples/Library?id=questiontype-matrixdynamic&platform=Reactjs&theme=modern#content-result)

![Screenshot 2020-07-14 at 15 08 08](https://user-images.githubusercontent.com/2305016/87439220-6cffa800-c5e8-11ea-806b-7eb13b869916.png)


