### PR TITLE
docs: Fix simple typo, beacuse -> because

### DIFF
--- a/testCafe/questions/checkboxes.js
+++ b/testCafe/questions/checkboxes.js
@@ -173,7 +173,7 @@ frameworks.forEach((framework) => {
       }
     }
 
-    assert(rnd_count >= 4); // beacuse of 'none', 'asc', 'desc' and if 4 it is really rnd
+    assert(rnd_count >= 4); // because of 'none', 'asc', 'desc' and if 4 it is really rnd
   });
 
   test(`check integrity`, async (t) => {

--- a/testCafe/questions/dropdown.js
+++ b/testCafe/questions/dropdown.js
@@ -115,7 +115,7 @@ frameworks.forEach(framework => {
       }
     }
 
-    assert(rnd_count >= 4); // beacuse of 'none', 'asc', 'desc' and if 4 it is really rnd
+    assert(rnd_count >= 4); // because of 'none', 'asc', 'desc' and if 4 it is really rnd
   });
 
   test(`check integrity`, async t => {

--- a/testCafe/questions/radiogroup.js
+++ b/testCafe/questions/radiogroup.js
@@ -143,7 +143,7 @@ frameworks.forEach(framework => {
       }
     }
 
-    assert(rnd_count >= 4); // beacuse of 'none', 'asc', 'desc' and if 4 it is really rnd
+    assert(rnd_count >= 4); // because of 'none', 'asc', 'desc' and if 4 it is really rnd
   });
 
   test(`check integrity`, async t => {


### PR DESCRIPTION
There is a small typo in testCafe/questions/checkboxes.js, testCafe/questions/dropdown.js, testCafe/questions/radiogroup.js.

Should read `because` rather than `beacuse`.

