### PR TITLE
v-model="row.value"  is redundant in matrix `td` input

### DIFF
--- a/src/vue/matrix.vue
+++ b/src/vue/matrix.vue
@@ -53,7 +53,6 @@
                   type="radio"
                   :class="question.cssClasses.itemValue"
                   :name="row.fullName"
-                  v-model="row.value"
                   :value="column.value"
                   :disabled="question.isReadOnly"
                   :id="question.inputId + '_' + row.name + '_' + columnIndex"


### PR DESCRIPTION
click event is handled by `td cellClick` .  It cause no problem in radio button, but when extend the input to `checkbox` will be trouble.