### PR TITLE
allow rating questions to be reset

### DIFF
--- a/src/knockout/templates/question-rating.html
+++ b/src/knockout/templates/question-rating.html
@@ -7,7 +7,7 @@
             <!-- ko foreach: question.koVisibleRateValues -->
             <label data-bind="css: question.koGetCss($data)">
                 <input
-                type="radio"
+                type="checkbox"
                 class="sv-visuallyhidden"
                 data-bind="attr: { name: question.name, id: question.inputId + '_' + $index(), value: $data.value, 'aria-required': question.isRequired, 'aria-label': $data.locText.text, 'aria-invalid': question.errors.length > 0, 'aria-describedby': question.errors.length > 0 ? question.id + '_errors' : null }, checkedValue: $data.value, checked: question.value, enable: !question.isInputReadOnly"
                 />

--- a/src/question_rating.ts
+++ b/src/question_rating.ts
@@ -179,6 +179,16 @@ export class QuestionRatingModel extends Question {
     }
     return !isNaN(val) ? parseFloat(val) : val;
   }
+  /**
+   * Click value again to clear.
+   */
+  public setValueFromClick(value: any) {
+    if (this.value === parseFloat(value)) {
+      this.clearValue();
+    } else {
+      this.value = value;
+    }
+  }
 }
 Serializer.addClass(
   "rating",

--- a/src/react/reactquestion_rating.tsx
+++ b/src/react/reactquestion_rating.tsx
@@ -8,14 +8,18 @@ import { ReactQuestionFactory } from "./reactquestion_factory";
 export class SurveyQuestionRating extends SurveyQuestionElementBase {
   constructor(props: any) {
     super(props);
-    this.handleOnChange = this.handleOnChange.bind(this);
+    this.handleOnClick = this.handleOnClick.bind(this);
   }
   protected get question(): QuestionRatingModel {
     return this.questionBase as QuestionRatingModel;
   }
-  handleOnChange(event: any) {
-    this.question.value = event.target.value;
-    this.setState({ value: this.question.value });
+  handleOnClick(event: any) {
+    if (this.question.value === parseFloat(event.target.value)) {
+      this.question.clearValue();
+    } else {
+      this.question.value = event.target.value;
+      this.setState({ value: this.question.value });
+    }
   }
   protected renderElement(): JSX.Element {
     var cssClasses = this.question.cssClasses;
@@ -82,7 +86,8 @@ export class SurveyQuestionRating extends SurveyQuestionElementBase {
           value={item.value}
           disabled={this.isDisplayMode}
           checked={this.question.value == item.value}
-          onChange={this.handleOnChange}
+          readOnly
+          onClick={this.handleOnClick}
           aria-required={this.question.isRequired}
           aria-label={item.locText.text}
           aria-invalid={this.question.errors.length > 0}

--- a/src/react/reactquestion_rating.tsx
+++ b/src/react/reactquestion_rating.tsx
@@ -14,12 +14,8 @@ export class SurveyQuestionRating extends SurveyQuestionElementBase {
     return this.questionBase as QuestionRatingModel;
   }
   handleOnClick(event: any) {
-    if (this.question.value === parseFloat(event.target.value)) {
-      this.question.clearValue();
-    } else {
-      this.question.value = event.target.value;
-      this.setState({ value: this.question.value });
-    }
+    this.question.setValueFromClick(event.target.value);
+    this.setState({ value: this.question.value });
   }
   protected renderElement(): JSX.Element {
     var cssClasses = this.question.cssClasses;

--- a/src/vue/rating.vue
+++ b/src/vue/rating.vue
@@ -15,7 +15,7 @@
             :id="question.inputId + '_' + index"
             :value="item.value"
             :disabled="question.isInputReadOnly"
-            @click="click"
+            @click="(e) => question.setValueFromClick(e.target.value)"
             v-bind:aria-required="question.isRequired"
             :aria-label="item.locText.text"
             :aria-invalid="question.errors.length > 0"
@@ -60,13 +60,6 @@ export class Rating extends QuestionVue<QuestionRatingModel> {
       css = css + " " + question.cssClasses.selected;
     }
     return css;
-  }
-  click(e: any) {
-    if (this.question.value === parseFloat(e.target.value)) {
-      this.question.clearValue();
-    } else {
-      this.question.value = e.target.value;
-    }
   }
   getRootClass(question: QuestionRatingModel) {
     const classes = question.cssClasses;

--- a/src/vue/rating.vue
+++ b/src/vue/rating.vue
@@ -15,7 +15,7 @@
             :id="question.inputId + '_' + index"
             :value="item.value"
             :disabled="question.isInputReadOnly"
-            @change="change"
+            @click="click"
             v-bind:aria-required="question.isRequired"
             :aria-label="item.locText.text"
             :aria-invalid="question.errors.length > 0"
@@ -61,8 +61,12 @@ export class Rating extends QuestionVue<QuestionRatingModel> {
     }
     return css;
   }
-  change(e: any) {
-    this.question.value = e.target.value;
+  click(e: any) {
+    if (this.question.value === parseFloat(e.target.value)) {
+      this.question.clearValue();
+    } else {
+      this.question.value = e.target.value;
+    }
   }
   getRootClass(question: QuestionRatingModel) {
     const classes = question.cssClasses;

--- a/tests/surveyquestiontests.ts
+++ b/tests/surveyquestiontests.ts
@@ -3861,7 +3861,7 @@ QUnit.test(
 
     q2.value = "2019-01-01";
     assert.equal(
-      new Date(q2.value).getFullYear(),
+      new Date(q2.value).getUTCFullYear(),
       2019,
       "Value new Date('2019-01-01') is set into question"
     );
@@ -3872,45 +3872,45 @@ QUnit.test(
     );
     q2.value = "2022-01-01";
     assert.equal(
-      new Date(q2.value).getFullYear(),
+      new Date(q2.value).getUTCFullYear(),
       2022,
       "Value new Date('2022-01-01') is set into question"
     );
     assert.equal(
-      new Date(survey.getValue("q2")).getFullYear(),
+      new Date(survey.getValue("q2")).getUTCFullYear(),
       2022,
       "Value new Date('2022-01-01') is set into survey"
     );
     q2.value = "2020-01-01";
     assert.equal(
-      new Date(q2.value).getFullYear(),
+      new Date(q2.value).getUTCFullYear(),
       2020,
       "Value new Date('2020-01-01') is set into question"
     );
     assert.equal(
-      new Date(survey.getValue("q2")).getFullYear(),
+      new Date(survey.getValue("q2")).getUTCFullYear(),
       2020,
       "Value new Date('2020-01-01') is set into survey"
     );
     q2.value = "2031-01-01";
     assert.equal(
-      new Date(q2.value).getFullYear(),
+      new Date(q2.value).getUTCFullYear(),
       2031,
       "Value new Date('2031-01-01') is set into question"
     );
     assert.equal(
-      new Date(survey.getValue("q2")).getFullYear(),
+      new Date(survey.getValue("q2")).getUTCFullYear(),
       2020,
       "Value new Date('2031-01-01') is not set into survey"
     );
     q2.value = "2030-01-01";
     assert.equal(
-      new Date(q2.value).getFullYear(),
+      new Date(q2.value).getUTCFullYear(),
       2030,
       "Value Date('2030-01-01') is set into question"
     );
     assert.equal(
-      new Date(survey.getValue("q2")).getFullYear(),
+      new Date(survey.getValue("q2")).getUTCFullYear(),
       2030,
       "Value new Date('2030-01-01') is set into survey"
     );
@@ -4014,6 +4014,20 @@ QUnit.test(
     assert.strictEqual(question.value, 1, "Convert to item.value, 1");
     question.value = undefined;
     assert.strictEqual(question.value, undefined, "undefined 2");
+  }
+);
+
+QUnit.test(
+  "QuestionRating value is reset when clicked again, Issue#2886",
+  function(assert) {
+    var question = new QuestionRatingModel("q");
+    question.setValueFromClick("1");
+    assert.strictEqual(question.value, 1, "Set to 1");
+    question.setValueFromClick("2");
+    assert.strictEqual(question.value, 2, "Set to 2");
+    question.setValueFromClick("2");
+    assert.notStrictEqual(question.value, 2, "No longer 2");
+    assert.strictEqual(isNaN(question.value), true, "Value is reset");
   }
 );
 


### PR DESCRIPTION
Hi, loving surveyjs so far! 

I had a use case where rating questions needed to be reset after a value had already been selected. This PR allows users to click on the value again to clear it. 

And I could not think of any reason why this should not be allowed. By default there is no value anyway. 

I had some trouble running the karma tests but I was able to manually verify it is working by checking each of the sample pages. 

Please let me know if this PR is okay. Thanks!