### PR TITLE
fix for the https://github.com/surveyjs/survey-creator/issues/1597

### DIFF
--- a/src/dragdrophelper.ts
+++ b/src/dragdrophelper.ts
@@ -298,8 +298,7 @@ export class DragDropHelper extends Base {
 
     if (
       DragDropHelper.restrictDragQuestionBetweenPages &&
-      dropTargetSurveyElement["page"] !==
-        (<any>this.draggedSurveyElement)["page"]
+      this.shouldRestricDragQuestionBetweenPages(dropTargetSurveyElement)
     ) {
       this.banDropSurveyElement();
       return;
@@ -320,6 +319,18 @@ export class DragDropHelper extends Base {
     this.isBottom = isBottom;
     this.dropTargetSurveyElement = dropTargetSurveyElement;
     this.insertGhostElementIntoSurvey();
+  }
+
+  private shouldRestricDragQuestionBetweenPages(
+    dropTargetSurveyElement: any
+  ): boolean {
+    const oldPage = (<any>this.draggedSurveyElement)["page"];
+    const newPage = dropTargetSurveyElement.isPage
+      ? dropTargetSurveyElement
+      : dropTargetSurveyElement["page"];
+
+    // if oldPage === null then it is drom the toolbox
+    return oldPage && oldPage !== newPage;
   }
 
   private getDragInfo(event: PointerEvent) {


### PR DESCRIPTION
https://github.com/surveyjs/survey-creator/issues/1597

When `restrictDragQuestionBetweenPages` is set to true

```js
SurveyCreator.settings.dragDrop.restrictDragQuestionBetweenPages = true;
```

it also restricts drag element from the toolbox, but it shouldn't be so

based on the https://surveyjs.answerdesk.io/ticket/details/T7387