### PR TITLE
doPropertyValueChangedCallback mismatch

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -465,7 +465,7 @@ export class Base {
     if (!target) target = this;
     var notifier: any = this.getSurvey();
     if (!notifier) notifier = this;
-    if (!!notifier.doPropertyValueChangedCallback) {
+    if (notifier !== this && !!notifier.doPropertyValueChangedCallback) {
       notifier.doPropertyValueChangedCallback(
         name,
         oldValue,

--- a/src/base.ts
+++ b/src/base.ts
@@ -466,7 +466,7 @@ export class Base {
     var notifier: any = this.getSurvey();
     if (!notifier) notifier = this;
     if (!!notifier.doPropertyValueChangedCallback) {
-      notifier.onPropertyValueChangedCallback(
+      notifier.doPropertyValueChangedCallback(
         name,
         oldValue,
         newValue,


### PR DESCRIPTION
The `doPropertyValueChangedCallback` function is checked, but `onPropertyValueChangedCallback` was called.