### PR TITLE
Only apply aria-labelledby if an aria-role is set

### DIFF
--- a/src/knockout/templates/question.html
+++ b/src/knockout/templates/question.html
@@ -1,5 +1,5 @@
 ﻿<script type="text/html" id="survey-question">
-  <div data-bind="css: question.koRootCss(), style: { paddingLeft: question.paddingLeft, paddingRight: question.paddingRight }, attr: { id: question.id, name: question.name, role: question.ariaRole, 'aria-labelledby': question.hasTitle ? question.ariaTitleId : null }">
+  <div data-bind="css: question.koRootCss(), style: { paddingLeft: question.paddingLeft, paddingRight: question.paddingRight }, attr: { id: question.id, name: question.name, role: question.ariaRole, 'aria-labelledby': question.hasTitle && question.ariaRole ? question.ariaTitleId : null }">
       <!-- ko if: question.hasTitleOnLeftTop -->
       <!--ko template: { name: 'survey-question-title', data: question  } -->
       <!-- /ko -->

--- a/src/react/reactquestion.tsx
+++ b/src/react/reactquestion.tsx
@@ -124,7 +124,7 @@ export class SurveyQuestion extends SurveyElementBase<any, any> {
         className={question.getRootCss()}
         style={rootStyle}
         role={question.ariaRole}
-        aria-labelledby={question.hasTitle ? question.ariaTitleId : null}
+        aria-labelledby={question.hasTitle && question.ariaRole ? question.ariaTitleId : null}
       >
         {headerTop}
         <div className={question.cssContent} style={contentStyle}>

--- a/src/vue/row.vue
+++ b/src/vue/row.vue
@@ -16,7 +16,7 @@
       <survey-element
         :id="element.id"
         :role="element.ariaRole"
-        :aria-labelledby="element.hasTitle ? element.ariaTitleId : null"
+        :aria-labelledby="element.hasTitle && element.ariaRole ? element.ariaTitleId : null"
         :name="element.name"
         :style="{
           paddingLeft: element.paddingLeft,


### PR DESCRIPTION
From [2.10 Practical Support: aria-label, aria-labelledby and aria-describedby](https://www.w3.org/TR/using-aria/#label-support): 

> Don't use aria-label or aria-labelledby on a span or div **_unless_** its given a role. When aria-label or aria-labelledby are on interactive roles (such as a link or button) or an img role, they override the contents of the div or span. Other roles besides Landmarks (discussed above) are ignored.

I updated each question template to only set this attribute if a role was also provided

Before and after test results using the [ARC toolkit](https://chrome.google.com/webstore/detail/arc-toolkit/chdkkkccnlfncngelccgbgfmjebmkmce?hl=en):

![Screen Shot 2021-09-02 at 12 17 30 PM](https://user-images.githubusercontent.com/9619457/131896046-5a09c463-786e-475d-81ec-bc2e30a612a7.png)

![Screen Shot 2021-09-02 at 12 15 52 PM](https://user-images.githubusercontent.com/9619457/131895879-848b8266-5279-4e7b-9e40-df7b2cd62afd.png)
