### PR TITLE
Revert "Only apply aria-labelledby if an aria-role is set"

### DIFF
--- a/src/knockout/templates/question.html
+++ b/src/knockout/templates/question.html
@@ -1,5 +1,5 @@
 ﻿<script type="text/html" id="survey-question">
-  <div data-bind="css: question.koRootCss(), style: { paddingLeft: question.paddingLeft, paddingRight: question.paddingRight }, attr: { id: question.id, name: question.name, role: question.ariaRole, 'aria-labelledby': question.hasTitle && question.ariaRole ? question.ariaTitleId : null }">
+  <div data-bind="css: question.koRootCss(), style: { paddingLeft: question.paddingLeft, paddingRight: question.paddingRight }, attr: { id: question.id, name: question.name, role: question.ariaRole, 'aria-labelledby': question.hasTitle ? question.ariaTitleId : null }">
       <!-- ko if: question.hasTitleOnLeftTop -->
       <!--ko template: { name: 'survey-question-title', data: question  } -->
       <!-- /ko -->

--- a/src/react/reactquestion.tsx
+++ b/src/react/reactquestion.tsx
@@ -124,7 +124,7 @@ export class SurveyQuestion extends SurveyElementBase<any, any> {
         className={question.getRootCss()}
         style={rootStyle}
         role={question.ariaRole}
-        aria-labelledby={question.hasTitle && question.ariaRole ? question.ariaTitleId : null}
+        aria-labelledby={question.hasTitle ? question.ariaTitleId : null}
       >
         {headerTop}
         <div className={question.cssContent} style={contentStyle}>

--- a/src/vue/row.vue
+++ b/src/vue/row.vue
@@ -16,7 +16,7 @@
       <survey-element
         :id="element.id"
         :role="element.ariaRole"
-        :aria-labelledby="element.hasTitle && element.ariaRole ? element.ariaTitleId : null"
+        :aria-labelledby="element.hasTitle ? element.ariaTitleId : null"
         :name="element.name"
         :style="{
           paddingLeft: element.paddingLeft,


### PR DESCRIPTION
Reverts surveyjs/survey-library#3251
@andrewnoyes @dmitrykurmanov I am reverting this PR.
We have "role" setup for checkbox question only. Removing "aria-labelledby" , in fact from all questions except "checkbox" kills several our TestCafe tests and I beleive functional tests for many our customers.
We have to create a property for "ariaLabelledBy" test it properly for all question types and then use it in html rendering.
The current PR creates different problems.

Thank you,
Andrew