### PR TITLE
Avoid double timer event execution on running survey the second time …

### DIFF
--- a/src/surveytimer.ts
+++ b/src/surveytimer.ts
@@ -1,7 +1,5 @@
 import { Event } from "./base";
 
-var counterStart = 0;
-
 export var surveyTimerFunctions = {
   setTimeout: function (func: () => any): number {
     if (typeof window === "undefined") return 0;


### PR DESCRIPTION
…fixed #3534