### PR TITLE
DnD: Empty Panel problem 

### DIFF
--- a/src/dragdrop/survey-elements.ts
+++ b/src/dragdrop/survey-elements.ts
@@ -158,7 +158,7 @@ export class DragDropSurveyElements extends DragDropCore<any> {
     if (this.dropTarget === this.ghostSurveyElement) return true;
     return (
       this.dropTarget === this.prevDropTarget && newIsBottom === this.isBottom
-      /*&&this.isEdge === this.prevIsEdge*/
+      && this.isEdge === this.prevIsEdge
     );
   }
 


### PR DESCRIPTION
When drag inside empty panel and then try to drag next to panel nothing happens. But drag indication should changed ( from green background to the orange strip )