### PR TITLE
Add Flemish language

### DIFF
--- a/src/localization/nl-BE.ts
+++ b/src/localization/nl-BE.ts
@@ -1,0 +1,10 @@
+import { surveyLocalization } from "../surveyStrings";
+import {dutchSurveyStrings} from "./dutch";
+
+/**
+ * This is initialized as a copy of the Dutch strings, when they start to deviate a choice has to be made:
+ * - Copy the Dutch set once and move forward as if it are 2 totally different languages
+ * - Override the relevant strings only
+ */
+surveyLocalization.locales["nl-BE"] = dutchSurveyStrings;
+surveyLocalization.localeNames["nl-BE"] = "vlaams";


### PR DESCRIPTION
This PR adds Flemish by copying the Dutch strings.

I've chosen to name the file using the common rf4646(https://www.rfc-editor.org/rfc/rfc4646) format. Since Flemish doesn't have a separate ISO639 code there was no standardized alternative.

Since the script is optional and won't apply to most languages, I've chosen to omit it, so we get: `nl-BE` insteadof `nl-Latn-BE`

## Future ideas
The idea behind this format is that we get several (future) benefits:
- We have automatic fallback of locales
- We can optionally expand localization to include different tones (formal vs informal), using private extensions: `nl-NL-x-informal` _Dutch as spoken in the Netherlands, formal_

Consider the English language with ISO639 code `en`. We could add US English as `en-US`. 
Whenever a locale is requested we can simplify use the separator to create a fallback mechanism:

```ts
getLocaleStrings(loc: string): any {
    // Short circuit 
    if (this.locales[loc]) {
        return this.locales[loc];
    }
    // Fallback
    const parts = loc.split("-");
    while (parts.length > 0) {
        parts.pop();
        if (this.locales[parts.join("-")]) {
            return this.locales[parts.join("-")]
        }
    }
    // Currently no explicit error is thrown, you'd just get an `undefined` result. In the future it might make sense to actually throw an error, or just default to English.
    
   
  },
```