### PR TITLE
Update dutch.ts

### DIFF
--- a/src/localization/dutch.ts
+++ b/src/localization/dutch.ts
@@ -8,7 +8,7 @@ export var dutchSurveyStrings = {
   completeText: "Verzenden",
   previewText: "Voorbeeld",
   editText: "Bewerk",
-  startSurveyText: "Begin met",
+  startSurveyText: "Start",
   otherItemText: "Anders, nl.",
   noneItemText: "Geen",
   selectAllItemText: "Selecteer Alles",


### PR DESCRIPTION
In Dutch `begin met` translates to `start with`, which requires a subject. (Start with what?)
`Starten` in itself is also a dutch verb and is more smooth than `Beginnen` when used on a button.