### PR TITLE
Switch to dart-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "madge": "^4.0.2",
     "mini-css-extract-plugin": "^0.9.0",
     "minimist": "^1.2.5",
-    "node-sass": "^4.14.1",
+    "sass": "^1",
     "node-uuid": "^1.4.8",
     "puppeteer": "^1.19.0",
     "qunit": "2.14.0",


### PR DESCRIPTION
Since `libsass` has been deprecated for more than a year now and the node-sass version you were depending on was very old I tried upgrading to `dart-sass` as recommended in the linked article.

https://sass-lang.com/blog/libsass-is-deprecated

This also got rid of the issues with having an ancient `node-gyp` version that no longer works with python etc etc.

It should be a drop-in replacement, after upgrading the build command worked for me.