### PR TITLE
Add support for complex default values

### DIFF
--- a/src/itemvalue.ts
+++ b/src/itemvalue.ts
@@ -84,12 +84,8 @@ export class ItemValue extends Base implements ILocalizableOwner, IShortcutText 
     items.length = 0;
     for (let i = 0; i < values.length; i++) {
       const value = values[i];
-      let item: ItemValue;
-      if (typeof value.getType === "function") {
-        item = Serializer.createClass(value.getType());
-      } else {
-        item = Serializer.createClass(type ?? "itemvalue");
-      }
+      const itemType = !!value && typeof value.getType === "function" ? value.getType() : (type ?? "itemvalue");
+      const item = Serializer.createClass(itemType);
       item.setData(value);
       if (!!value.originalItem) {
         item.originalItem = value.originalItem;

--- a/src/itemvalue.ts
+++ b/src/itemvalue.ts
@@ -353,7 +353,7 @@ export class ItemValue extends Base implements ILocalizableOwner, IShortcutText 
       if (typeof value.toJSON === "function") {
         json = (<Base>value).toJSON();
       } else {
-        json = value
+        json = value;
       }
       new JsonObject().toObject(json, this);
     } else {

--- a/src/itemvalue.ts
+++ b/src/itemvalue.ts
@@ -76,15 +76,19 @@ export class ItemValue extends Base implements ILocalizableOwner, IShortcutText 
       return result;
     };
   }
-  public static setData(items: Array<ItemValue>, values: Array<any>) {
+
+  /**
+   * Resets the input array and fills it with values from the values array
+   */
+  public static setData(items: Array<ItemValue>, values: Array<any>, type?:string): void {
     items.length = 0;
-    for (var i = 0; i < values.length; i++) {
-      var value = values[i];
-      var item: ItemValue;
+    for (let i = 0; i < values.length; i++) {
+      const value = values[i];
+      let item: ItemValue;
       if (typeof value.getType === "function") {
         item = Serializer.createClass(value.getType());
       } else {
-        item = new ItemValue(null);
+        item = Serializer.createClass(type ?? "itemvalue");
       }
       item.setData(value);
       if (!!value.originalItem) {
@@ -345,9 +349,11 @@ export class ItemValue extends Base implements ILocalizableOwner, IShortcutText 
   public setData(value: any) {
     if (Helpers.isValueEmpty(value)) return;
     if (typeof value.value !== "undefined") {
-      var json = value;
+      let json;
       if (typeof value.toJSON === "function") {
         json = (<Base>value).toJSON();
+      } else {
+        json = value
       }
       new JsonObject().toObject(json, this);
     } else {
@@ -430,9 +436,10 @@ Base.createItemValue = function(source: any, type?: string): any {
 Base.itemValueLocStrChanged = function(arr: Array<any>): void {
   ItemValue.locStrsChanged(arr);
 };
-JsonObjectProperty.getItemValuesDefaultValue = function(val: any): any {
-  var res = new Array<ItemValue>();
-  ItemValue.setData(res, val || []);
+
+JsonObjectProperty.getItemValuesDefaultValue = (val: any, type: string): Array<ItemValue> => {
+  const res = new Array<ItemValue>();
+  ItemValue.setData(res, Array.isArray(val) ? val : [], type);
   return res;
 };
 

--- a/src/jsonobject.ts
+++ b/src/jsonobject.ts
@@ -169,7 +169,7 @@ export interface IObject {
  * @see [Remove Properties](https://surveyjs.io/Documentation/Survey-Creator#removeproperties)
  */
 export class JsonObjectProperty implements IObject {
-  public static getItemValuesDefaultValue: (val: any) => any;
+  public static getItemValuesDefaultValue: (val: any, type:string) => any;
   [key: string]: any;
   private static Index = 1;
   private static mergableValues = [
@@ -290,14 +290,12 @@ export class JsonObjectProperty implements IObject {
     return this.onGetValue || this.serializationProperty;
   }
   public get defaultValue() {
-    var result: any = this.defaultValueValue;
+    let result: any = this.defaultValueValue;
     if (
       !!JsonObjectProperty.getItemValuesDefaultValue &&
       JsonObject.metaData.isDescendantOf(this.className, "itemvalue")
     ) {
-      result = JsonObjectProperty.getItemValuesDefaultValue(
-        this.defaultValueValue || []
-      );
+      result = JsonObjectProperty.getItemValuesDefaultValue(this.defaultValueValue || [], this.className);
     }
     return result;
   }
@@ -305,8 +303,14 @@ export class JsonObjectProperty implements IObject {
     this.defaultValueValue = newValue;
   }
   public isDefaultValue(value: any): boolean {
-    if (!Helpers.isValueEmpty(this.defaultValue))
+    if (!Helpers.isValueEmpty(this.defaultValue)) {
+      // Complex default values.
+      if (Array.isArray(value) && Array.isArray(this.defaultValue)) {
+        return value.length === this.defaultValue.length
+            && JSON.stringify(value) === JSON.stringify(this.defaultValue);
+      }
       return this.defaultValue == value;
+    }
     return (
       (value === false && (this.type == "boolean" || this.type == "switch")) ||
       value === "" ||

--- a/src/jsonobject.ts
+++ b/src/jsonobject.ts
@@ -304,12 +304,7 @@ export class JsonObjectProperty implements IObject {
   }
   public isDefaultValue(value: any): boolean {
     if (!Helpers.isValueEmpty(this.defaultValue)) {
-      // Complex default values.
-      if (Array.isArray(value) && Array.isArray(this.defaultValue)) {
-        return value.length === this.defaultValue.length
-            && JSON.stringify(value) === JSON.stringify(this.defaultValue);
-      }
-      return this.defaultValue == value;
+      return Helpers.isTwoValueEquals(value, this.defaultValue, false, true, false);
     }
     return (
       (value === false && (this.type == "boolean" || this.type == "switch")) ||

--- a/tests/jsonobjecttests.ts
+++ b/tests/jsonobjecttests.ts
@@ -2571,3 +2571,36 @@ QUnit.test("override defaultValue of @property", function (assert) {
   const obj = new TestDeclaredProps();
   assert.equal(obj.numberProp, 10);
 });
+
+QUnit.test("Creator custom ItemValue class, and a property an array of custom ItemValue + default value ", function (assert) {
+  Serializer.addClass("coloritemvalue", [
+        { name: "text", visible: false },
+        { name: "color", type: "color" }],
+      null, "itemvalue");
+  Serializer.addProperty("car", { name: "colors",
+    default: [{ value: "A1", color: "#ff0000" }, { value: "A2", color: "#00ff00" }],
+    className: "coloritemvalue", type: "coloritemvalue[]" });
+
+  const car: any = new Car();
+  assert.equal(car.colors.length, 2, "There are two colors by default");
+  assert.equal(car.colors[0].value, "A1", "value set correctly #1");
+  assert.equal(car.colors[1].color, "#00ff00", "color set correctly #2");
+  assert.deepEqual(car.toJSON(), {}, "toJSON. It should be empty #3");
+  car.colors.splice(0, 1);
+  const newItem = new ItemValue("A3", undefined, "coloritemvalue");
+  newItem.color = "#ffffff";
+  car.colors.push(newItem);
+  assert.deepEqual(car.toJSON(), { colors: [{ value: "A2", color: "#00ff00" }, { value: "A3", color: "#ffffff" }] }, "toJSON #4");
+  car.fromJSON({
+    colors: [
+      { value: "B1", color: "-ff0000" },
+      { value: "B2", color: "-00ff00" },
+      { value: "B3", color: "-ffffff" }]
+  });
+  assert.equal(car.colors.length, 3, "There are three colors loaded #5");
+  assert.equal(car.colors[0].value, "B1", "value set correctly #6");
+  assert.equal(car.colors[2].color, "-ffffff", "color set correctly #7");
+
+  Serializer.removeProperty("car", "colors");
+  Serializer.removeClass("coloritemvalue");
+});


### PR DESCRIPTION
This PR implements complex default values.

- It adds support for comparison of complex values, so that they are not needlessly serialized to JSON.
- It allows `ItemValue` descendant typed properties to pass the type information for creating properties without requiring a custom constructor.