### PR TITLE
Work for https://github.com/surveyjs/survey-creator/issues/2966

### DIFF
--- a/src/knockout/kosurvey.ts
+++ b/src/knockout/kosurvey.ts
@@ -93,8 +93,8 @@ export class SurveyImplementor extends ImplementorBase {
   public koEventAfterRender(element: any, survey: any) {
     if(survey["needRenderIcons"]) {
       SvgRegistry.renderIcons();
-      survey.afterRenderSurvey(element);
     }
+    survey.afterRenderSurvey(element);
   }
   public dispose(): void {
     super.dispose();

--- a/src/question.ts
+++ b/src/question.ts
@@ -1861,17 +1861,14 @@ export class Question extends SurveyElement
         let isProcessed = false;
         let requiredWidth: number = undefined;
         this.resizeObserver = new ResizeObserver(() => {
-          if(!el.isConnected) { this.destroyResizeObserver(); }
-          else {
-            const rootEl = <HTMLElement>el.querySelector(scrollableSelector);
-            if(!requiredWidth && this.isDefaultRendering()) {
-              requiredWidth = rootEl.scrollWidth;
-            }
-            if(isProcessed || !isContainerVisible(rootEl)) {
-              isProcessed = false;
-            } else {
-              isProcessed = this.processResponsiveness(requiredWidth, getElementWidth(rootEl));
-            }
+          const rootEl = <HTMLElement>el.querySelector(scrollableSelector);
+          if(!requiredWidth && this.isDefaultRendering()) {
+            requiredWidth = rootEl.scrollWidth;
+          }
+          if(isProcessed || !isContainerVisible(rootEl)) {
+            isProcessed = false;
+          } else {
+            isProcessed = this.processResponsiveness(requiredWidth, getElementWidth(rootEl));
           }
         });
         this.onMobileChangedCallback = () => {
@@ -1905,6 +1902,7 @@ export class Question extends SurveyElement
       this.resizeObserver.disconnect();
       this.resizeObserver = undefined;
       this.onMobileChangedCallback = undefined;
+      this.renderAs = this.getDesktopRenderAs();
     }
   }
   public dispose() {

--- a/src/survey.ts
+++ b/src/survey.ts
@@ -4165,7 +4165,6 @@ export class SurveyModel extends SurveyElementCore
       if (!!mobileWidth) {
         let isProcessed = false;
         this.resizeObserver = new ResizeObserver(() => {
-          if (!observedElement.isConnected) { this.destroyResizeObserver(); return; }
           if(isProcessed || !isContainerVisible(observedElement)) {
             isProcessed = false;
           } else {

--- a/src/survey.ts
+++ b/src/survey.ts
@@ -1926,14 +1926,14 @@ export class SurveyModel extends SurveyElementCore
     }
   }
   private get isMobile() {
-    return isMobile() || this._isMobile;
+    return this._isMobile;
   }
   protected isLogoImageChoosen() {
     return this.locLogo.renderedHtml;
   }
   public get titleMaxWidth(): string {
     if (
-      !this.isMobile &&
+      !(isMobile() || this.isMobile) &&
       !this.isValueEmpty(this.isLogoImageChoosen()) &&
       !settings.supportCreatorV2
     ) {

--- a/tests/questionImagepicker.ts
+++ b/tests/questionImagepicker.ts
@@ -211,6 +211,7 @@ export class CustomResizeObserver {
   call() {
     this.callback();
   }
+  disconnect() {}
 }
 
 QUnit.test("check resizeObserver behavior", function(assert) {

--- a/tests/question_ratingtests.ts
+++ b/tests/question_ratingtests.ts
@@ -125,7 +125,14 @@ QUnit.test("check rating resize observer behavior", (assert) => {
   assert.equal(q1.renderAs, "dropdown");
   currentOffsetWidth = 400;
   (<any>q1["resizeObserver"]).call();
+  (<any>q1["resizeObserver"]).call(); //double process to reset isProcessed flag
   assert.equal(q1.renderAs, "default");
+  currentOffsetWidth = 200;
+  (<any>q1["resizeObserver"]).call();
+  (<any>q1["resizeObserver"]).call(); //double process to reset isProcessed flag
+  assert.equal(q1.renderAs, "dropdown");
+  q1["destroyResizeObserver"]();
+  assert.equal(q1.renderAs, "default", "https://github.com/surveyjs/survey-creator/issues/2966: after destroying resize observer renderAs should return to default state");
   window.getComputedStyle = getComputedStyle;
   window.ResizeObserver = ResizeObserver;
 });


### PR DESCRIPTION
Fix responsiveness for mobile preview in creator:

* fix resize observer for survey in Knockout (now independent from needRenderIcons flag)
* reset renderAs for responsive questions after destroying resize observer
* remove destoyResizeObserver call after element is disconnected (brokes reuse of components)