### PR TITLE
Work for #4257 - questionCount 1 or greater for progressBar calculation

### DIFF
--- a/src/survey.ts
+++ b/src/survey.ts
@@ -3043,14 +3043,14 @@ export class SurveyModel extends SurveyElementCore
     if (this.progressBarType !== "pages") {
       var info = this.getProgressInfo();
       if (this.progressBarType === "requiredQuestions") {
-        return info.requiredQuestionCount > 1
+        return info.requiredQuestionCount >= 1
           ? Math.ceil(
             (info.requiredAnsweredQuestionCount * 100) /
             info.requiredQuestionCount
           )
           : 100;
       }
-      return info.questionCount > 1
+      return info.questionCount >= 1
         ? Math.ceil((info.answeredQuestionCount * 100) / info.questionCount)
         : 100;
     }


### PR DESCRIPTION
fix for progressBar value defaulting to 100% for unanswered 1-question surveys. modified getProgress method to calculate progress percentage when question count is equal to 1