### PR TITLE
Add onBeforeCreateRequest Event

### DIFF
--- a/src/choicesRestful.ts
+++ b/src/choicesRestful.ts
@@ -586,6 +586,16 @@ export class ChoicesRestfull extends ChoicesRestful {
   public static clearCache() {
     ChoicesRestful.clearCache();
   }
+  public static get onBeforeCreateRequest(): (
+    sender: ChoicesRestful
+  ) => void {
+    return ChoicesRestful.onBeforeCreateRequest;
+  }
+  public static set onBeforeCreateRequest(
+    val: (sender: ChoicesRestful) => void
+  ) {
+    ChoicesRestful.onBeforeCreateRequest = val;
+  }
   public static get onBeforeSendRequest(): (
     sender: ChoicesRestful,
     options: { request: XMLHttpRequest }

--- a/src/choicesRestful.ts
+++ b/src/choicesRestful.ts
@@ -88,6 +88,9 @@ export class ChoicesRestful extends Base {
       }
     }
   }
+  public static onBeforeCreateRequest: (
+    sender: ChoicesRestful
+  ) => void;
   public static onBeforeSendRequest: (
     sender: ChoicesRestful,
     options: { request: XMLHttpRequest }
@@ -220,6 +223,9 @@ export class ChoicesRestful extends Base {
     return parsedResponse;
   }
   protected sendRequest() {
+    if (!!ChoicesRestful.onBeforeCreateRequest) {
+      ChoicesRestful.onBeforeCreateRequest(this);
+    }
     var xhr = new XMLHttpRequest();
     xhr.open("GET", this.processedUrl);
     xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");


### PR DESCRIPTION
onBeforeCreateRequest(Object: ChoicesRestful)
gives the ability to modify the ChoicesRestful object before the XMLHttpRequest is created