### PR TITLE
Work for #4554: do not process responsiveness if values difference is too small

### DIFF
--- a/src/defaultV2-theme/blocks/sd-question.scss
+++ b/src/defaultV2-theme/blocks/sd-question.scss
@@ -138,5 +138,6 @@
 }
 .sd-scrollable-container:not(.sd-scrollable-container--compact) {
   width: max-content;
+  overflow-x: hidden;
   max-width: 100%;
 }

--- a/src/question.ts
+++ b/src/question.ts
@@ -1929,13 +1929,13 @@ export class Question extends SurveyElement
   protected processResponsiveness(requiredWidth: number, availableWidth: number): any {
     availableWidth = Math.round(availableWidth);
     if (Math.abs(requiredWidth - availableWidth) > 2) {
-    const oldRenderAs = this.renderAs;
+      const oldRenderAs = this.renderAs;
       if (requiredWidth > availableWidth) {
-      this.renderAs = this.getCompactRenderAs();
-    } else {
-      this.renderAs = this.getDesktopRenderAs();
-    }
-    return oldRenderAs !== this.renderAs;
+        this.renderAs = this.getCompactRenderAs();
+      } else {
+        this.renderAs = this.getDesktopRenderAs();
+      }
+      return oldRenderAs !== this.renderAs;
     }
     return false;
   }

--- a/src/question.ts
+++ b/src/question.ts
@@ -1928,13 +1928,16 @@ export class Question extends SurveyElement
   }
   protected processResponsiveness(requiredWidth: number, availableWidth: number): any {
     availableWidth = Math.round(availableWidth);
+    if (Math.abs(requiredWidth - availableWidth) > 2) {
     const oldRenderAs = this.renderAs;
-    if(requiredWidth > availableWidth) {
+      if (requiredWidth > availableWidth) {
       this.renderAs = this.getCompactRenderAs();
     } else {
       this.renderAs = this.getDesktopRenderAs();
     }
     return oldRenderAs !== this.renderAs;
+    }
+    return false;
   }
   private destroyResizeObserver() {
     if(!!this.resizeObserver) {

--- a/tests/question_ratingtests.ts
+++ b/tests/question_ratingtests.ts
@@ -189,6 +189,27 @@ QUnit.test("check rating useDropdown", (assert) => {
   q1["processResponsiveness"](600, 500);
   assert.equal(q1.renderAs, "dropdown", "useDropdown=always, big size, dropdown");
 });
+QUnit.test("do not process reponsiveness when required width differs from avalailable less then 2px: #4554", (assert) => {
+  var json = {
+    questions: [
+      {
+        type: "rating",
+        name: "q1",
+      },
+    ],
+  };
+  const survey = new SurveyModel(json);
+  const q1 = <QuestionRatingModel>survey.getQuestionByName("q1");
+  assert.equal(q1["processResponsiveness"](502, 500), false);
+  assert.equal(q1.renderAs, "default", "difference too small: not processed");
+  assert.equal(q1["processResponsiveness"](503, 500), true);
+  assert.equal(q1.renderAs, "dropdown", "difference is enough: is processed");
+  q1["processResponsiveness"](503, 500) // dummy: to reset isProcessed flag
+  assert.equal(q1["processResponsiveness"](500, 502), false);
+  assert.equal(q1.renderAs, "dropdown", "difference too small: not processed");
+  assert.equal(q1["processResponsiveness"](500, 503), true);
+  assert.equal(q1.renderAs, "default", "difference is enough: processed");
+});
 QUnit.test("check getItemClass in display mode", (assert) => {
   var json = {
     questions: [


### PR DESCRIPTION
When zoom occurs available width becomes smaller less than 1px (due to accuracy), and it causes turning rating into dropdown. We should ignore this case and do not process responsivess for rating question