### PR TITLE
Rename property and update description

### DIFF
--- a/src/question.ts
+++ b/src/question.ts
@@ -245,14 +245,14 @@ export class Question extends SurveyElement<Question>
     }
   }
   /**
-   * Specifies whether to use display names for question values in placeholders. 
+   * Specifies whether to use display names for question values in placeholders.
    * This property is used for questions whose values define the `value` and `text` properties (for example, a Radiogroup `choice` option with `value` and `text`).
-   * 
+   *
    * Question placeholders can be used in the following places:
    * - Survey element titles and descriptions;
    * - The `expression` property of the Expression question;
-   * - The `html` property of the HTML question.    
-   * 
+   * - The `html` property of the HTML question.
+   *
    * To use a question value as a placeholder, specify the question `name` in curly brackets: `{questionName}`.
    *
    * Default value: `true`
@@ -2034,7 +2034,7 @@ Serializer.addClass("question", [
     choices: ["default", "collapsed", "expanded"],
   },
   { name: "visible:switch", default: true },
-  { name: "useDisplayValueInPlaceholders:boolean", default: true, layout: "row" },
+  { name: "useDisplayValueInPlaceholders:boolean", alternativeName: "useDisplayValuesInTitle", default: true, layout: "row" },
   "visibleIf:condition",
   { name: "width" },
   { name: "minWidth", default: settings.minWidth },

--- a/src/question.ts
+++ b/src/question.ts
@@ -245,19 +245,25 @@ export class Question extends SurveyElement<Question>
     }
   }
   /**
-   * Specifies whether to use display names for question values interpolated in the title. To interpolate question values, use curly brackets (`{}`).
-   *
-   * This property is useful when interpolated question values have both the `value` and `text` properties.
+   * Specifies whether to use display names for question values in placeholders. 
+   * This property is used for questions whose values define the `value` and `text` properties (for example, a Radiogroup `choice` option with `value` and `text`).
+   * 
+   * Question placeholders can be used in the following places:
+   * - Survey element titles and descriptions;
+   * - The `expression` property of the Expression question;
+   * - The `html` property of the HTML question.    
+   * 
+   * To use a question value as a placeholder, specify the question `name` in curly brackets: `{questionName}`.
    *
    * Default value: `true`
    */
-  public get useDisplayValuesInTitle(): boolean {
-    return this.getPropertyValue("useDisplayValuesInTitle");
+  public get useDisplayValueInPlaceholders(): boolean {
+    return this.getPropertyValue("useDisplayValueInPlaceholders");
   }
-  public set useDisplayValuesInTitle(val: boolean) {
-    this.setPropertyValue("useDisplayValuesInTitle", val);
+  public set useDisplayValueInPlaceholders(val: boolean) {
+    this.setPropertyValue("useDisplayValueInPlaceholders", val);
   }
-  protected getUseDisplayValuesInTitle(): boolean { return this.useDisplayValuesInTitle; }
+  protected getUseDisplayValueInPlaceholders(): boolean { return this.useDisplayValueInPlaceholders; }
   /**
    * A Boolean expression. If it evaluates to `false`, this question becomes hidden.
    *
@@ -784,7 +790,7 @@ export class Question extends SurveyElement<Question>
     return this.showErrorOnCore("bottom");
   }
   protected getIsTooltipErrorSupportedByParent(): boolean {
-    if(this.parentQuestion) {
+    if (this.parentQuestion) {
       return this.parentQuestion.getIsTooltipErrorInsideSupported();
     } else {
       return super.getIsTooltipErrorSupportedByParent();
@@ -909,8 +915,8 @@ export class Question extends SurveyElement<Question>
     }
   }
   private expandAllPanels(panel: IPanel) {
-    if(!!panel && !!panel.parent) {
-      if(panel.isCollapsed) {
+    if (!!panel && !!panel.parent) {
+      if (panel.isCollapsed) {
         panel.expand();
       }
       this.expandAllPanels(panel.parent);
@@ -2028,7 +2034,7 @@ Serializer.addClass("question", [
     choices: ["default", "collapsed", "expanded"],
   },
   { name: "visible:switch", default: true },
-  { name: "useDisplayValuesInTitle:boolean", default: true, layout: "row" },
+  { name: "useDisplayValueInPlaceholders:boolean", default: true, layout: "row" },
   "visibleIf:condition",
   { name: "width" },
   { name: "minWidth", default: settings.minWidth },

--- a/src/questionnonvalue.ts
+++ b/src/questionnonvalue.ts
@@ -38,7 +38,7 @@ export class QuestionNonValue extends Question {
   public addConditionObjectsByContext(
     objects: Array<IConditionObject>,
     context: any
-  ) {}
+  ) { }
   public getConditionJson(operator: string = null, path: string = null): any {
     return null;
   }
@@ -59,7 +59,7 @@ Serializer.addClass(
     { name: "requiredIf", visible: false },
     { name: "validators", visible: false },
     { name: "titleLocation", visible: false },
-    { name: "useDisplayValuesInTitle", visible: false },
+    { name: "useDisplayValueInPlaceholders", visible: false },
   ],
   function () {
     return new QuestionNonValue("");

--- a/src/questionnonvalue.ts
+++ b/src/questionnonvalue.ts
@@ -59,7 +59,7 @@ Serializer.addClass(
     { name: "requiredIf", visible: false },
     { name: "validators", visible: false },
     { name: "titleLocation", visible: false },
-    { name: "useDisplayValueInPlaceholders", visible: false },
+    { name: "useDisplayValueInPlaceholders", alternativeName: "useDisplayValuesInTitle", visible: false },
   ],
   function () {
     return new QuestionNonValue("");

--- a/src/survey-element.ts
+++ b/src/survey-element.ts
@@ -675,11 +675,11 @@ export class SurveyElement<E = any> extends SurveyElementCore implements ISurvey
   public getProcessedText(text: string): string {
     if (this.isLoadingFromJson) return text;
     if (this.textProcessor)
-      return this.textProcessor.processText(text, this.getUseDisplayValuesInTitle());
+      return this.textProcessor.processText(text, this.getUseDisplayValueInPlaceholders());
     if (this.locOwner) return this.locOwner.getProcessedText(text);
     return text;
   }
-  protected getUseDisplayValuesInTitle(): boolean { return true; }
+  protected getUseDisplayValueInPlaceholders(): boolean { return true; }
   protected removeSelfFromList(list: Array<any>) {
     if (!list || !Array.isArray(list)) return;
     const index: number = list.indexOf(this);

--- a/tests/surveyShowPreviewTests.ts
+++ b/tests/surveyShowPreviewTests.ts
@@ -4,7 +4,7 @@ import { PanelModel } from "../src/panel";
 
 export default QUnit.module("SurveyShowPreviewTests");
 
-QUnit.test("Complete and Preview button visibility", function(assert) {
+QUnit.test("Complete and Preview button visibility", function (assert) {
   var survey = new SurveyModel({ elements: [{ type: "text", name: "q1" }] });
   assert.equal(survey.currentPageNo, 0, "Init current page");
   assert.equal(survey.isShowPreviewBeforeComplete, false, "no preview");
@@ -76,7 +76,7 @@ QUnit.test("Complete and Preview button visibility", function(assert) {
 
 QUnit.test(
   "showPreviewBeforeComplete = 'showAllQuestions', do not show preview if there is an error",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       pages: [
         { elements: [{ type: "text", name: "q1" }] },
@@ -113,7 +113,7 @@ QUnit.test(
 
 QUnit.test(
   "showPreviewBeforeComplete = 'showAllQuestions', check currentPage on showing preview",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       pages: [
         { elements: [{ type: "text", name: "q1" }] },
@@ -159,7 +159,7 @@ QUnit.test(
 );
 QUnit.test(
   "showPreviewBeforeComplete = 'showAllQuestions', restore pages before onComplete",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       pages: [
         { elements: [{ type: "text", name: "q1" }] },
@@ -176,7 +176,7 @@ QUnit.test(
 );
 QUnit.test(
   "showPreviewBeforeComplete = 'showAllQuestions', and do noting onCompleting, options.allowComplete = false",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       pages: [
         { elements: [{ type: "text", name: "q1" }] },
@@ -201,7 +201,7 @@ QUnit.test(
 
 QUnit.test(
   "showPreviewBeforeComplete = 'showAllQuestions', questionsOnPageMode = 'singlePage'",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       pages: [
         { elements: [{ type: "text", name: "q1" }] },
@@ -225,7 +225,7 @@ QUnit.test(
 );
 QUnit.test(
   "showPreviewBeforeComplete = 'showAllQuestions', questionsOnPageMode = 'questionPerPage'",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       pages: [
         {
@@ -277,7 +277,7 @@ QUnit.test(
     );
   }
 );
-QUnit.test("showPreviewBeforeComplete = 'showAnsweredQuestions'", function(
+QUnit.test("showPreviewBeforeComplete = 'showAnsweredQuestions'", function (
   assert
 ) {
   var survey = new SurveyModel({
@@ -316,7 +316,7 @@ QUnit.test("showPreviewBeforeComplete = 'showAnsweredQuestions'", function(
 });
 QUnit.test(
   "showPreviewBeforeComplete = 'showAllQuestions', edit page",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       pages: [
         { elements: [{ type: "text", name: "q1" }] },
@@ -381,7 +381,7 @@ QUnit.test(
 );
 QUnit.test(
   "showPreviewBeforeComplete = 'showAnsweredQuestions', edit page",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       pages: [
         { name: "p1", elements: [{ type: "text", name: "q1" }] },
@@ -407,7 +407,7 @@ QUnit.test(
 );
 QUnit.test(
   "showPreviewBeforeComplete = 'showAnsweredQuestions', do not hide questions on running state",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       pages: [
         { elements: [{ type: "text", name: "q1" }] },
@@ -421,7 +421,7 @@ QUnit.test(
 );
 QUnit.test(
   "showPreviewBeforeComplete = 'showAnsweredQuestions', Bug#2190",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       pages: [
         {
@@ -448,7 +448,7 @@ QUnit.test(
 );
 QUnit.test(
   "showPreviewBeforeComplete = 'showAllQuestions' invisible Page, Bug#2385",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       pages: [
         {
@@ -506,7 +506,7 @@ QUnit.test(
 );
 QUnit.test(
   "showPreviewBeforeComplete = 'showAllQuestions' onShowingPreview event",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       elements: [
         {
@@ -528,7 +528,7 @@ QUnit.test(
 );
 QUnit.test(
   "onShowingPreview && onServerValidateQuestions events",
-  function(assert) {
+  function (assert) {
     const survey = new SurveyModel({
       elements: [
         {
@@ -540,11 +540,11 @@ QUnit.test(
     let counterPreview = 0;
     let counterServer = 0;
     survey.onServerValidateQuestions.add(function (sender, options) {
-      counterServer ++;
+      counterServer++;
       options.complete();
     });
     survey.onShowingPreview.add((sender, options) => {
-      counterPreview ++;
+      counterPreview++;
     });
     assert.equal(counterServer, 0, "We do not call Server validation yet");
     assert.equal(counterPreview, 0, "We do not call showing preview yet");
@@ -556,7 +556,7 @@ QUnit.test(
 );
 QUnit.test(
   "showPreviewBeforeComplete = 'showAnsweredQuestions' and invisible matrix dropdown, Bug#3176",
-  function(assert) {
+  function (assert) {
     var survey = new SurveyModel({
       showPreviewBeforeComplete: "showAnsweredQuestions",
       pages: [
@@ -576,7 +576,7 @@ QUnit.test(
             {
               type: "matrixdropdown",
               name: "question3",
-              useDisplayValuesInTitle: false,
+              useDisplayValueInPlaceholders: false,
               isRequired: true,
               defaultValue: { item1: { col1: "val1" } },
               columns: [{ cellType: "text", name: "col1" }],
@@ -595,7 +595,7 @@ QUnit.test(
 );
 QUnit.test(
   "showPreviewBeforeComplete = 'showAnsweredQuestions' and goNextPageAutomatic, Bug#3450",
-  function(assert) {
+  function (assert) {
     const survey = new SurveyModel({
       "pages": [
         {

--- a/tests/surveytests.ts
+++ b/tests/surveytests.ts
@@ -8339,7 +8339,7 @@ QUnit.test("Survey get full title with values", function (assert) {
           { value: 1, text: "One" },
           { value: 2, text: "Two" },
         ],
-        useDisplayValuesInTitle: false,
+        useDisplayValueInPlaceholders: false,
       },
     ],
   };


### PR DESCRIPTION
Renamed the property:
useDisplayValuesInTitle ->
useDisplayValueInPlaceholders
Plus updated the description.

The reason: this property gets/sets whether to use a question value's `text` or `value` not only in titles, but also when calculating the rendered text for other parts of the questionnaire. 
