### PR TITLE
The Rating design area is unnecessary expanded when specifying a custom rate item caption

### DIFF
--- a/src/question_rating.ts
+++ b/src/question_rating.ts
@@ -355,7 +355,6 @@ export class QuestionRatingModel extends Question {
     const rateMin = this.getPropertyValue("rateMin");
     return this.displayMode != "dropdown" && !!(this.hasMinRateDescription ||
       this.hasMaxRateDescription ||
-      rateValues.length > 0 ||
       (rateStep && (rateMax - rateMin) / rateStep > 9));
   }
 

--- a/tests/surveywidthmodetests.ts
+++ b/tests/surveywidthmodetests.ts
@@ -183,5 +183,5 @@ QUnit.test("Survey widthMode property for rating questions", function (assert) {
       },
     ]
   });
-  assert.equal(survey3.calculateWidthMode(), "responsive", "rating with rate values widthMode is responsive");
+  assert.equal(survey3.calculateWidthMode(), "static", "rating with rate values widthMode is static");
 });


### PR DESCRIPTION
Fixes #5235