### PR TITLE
fix(matrix): export IMatrixDropdownData to allow extending MatrixDynamicRowModel

### DIFF
--- a/src/entries/chunks/model.ts
+++ b/src/entries/chunks/model.ts
@@ -86,6 +86,7 @@ export {
   propertyArray
 } from "../../jsonobject";
 export {
+  IMatrixDropdownData,
   MatrixDropdownCell,
   MatrixDropdownRowModelBase,
   QuestionMatrixDropdownModelBase


### PR DESCRIPTION
Since this is not currently exported, type checks will fails if you try to keep types consistent with the internal surveyjs types when extending MatrixDynamicRowModel.