### PR TITLE
custom none value for multiple-choice questions by adding a new noneValue prop

### DIFF
--- a/src/question_baseselect.ts
+++ b/src/question_baseselect.ts
@@ -183,6 +183,17 @@ export class QuestionSelectBase extends Question {
     return this.noneItemValue;
   }
   /**
+   * Gets or sets a value for the "None" choice item.
+   * @see showNoneItem
+   */
+  public get noneValue(): string {
+    return this.getPropertyValue("noneValue");
+  }
+  public set noneValue(val: string) {
+    this.setPropertyValue("noneValue",val);
+    this.noneItem.value = val
+  }
+  /**
    * Gets or sets a caption for the "None" choice item.
    * @see showNoneItem
    */
@@ -1721,6 +1732,13 @@ Serializer.addClass(
     {
       name: "noneText",
       serializationProperty: "locNoneText",
+      dependsOn: "showNoneItem",
+      visibleIf: function (obj: any) {
+        return obj.hasNone;
+      },
+    },
+    {
+      name: "noneValue",
       dependsOn: "showNoneItem",
       visibleIf: function (obj: any) {
         return obj.hasNone;


### PR DESCRIPTION
This is related to #5363 and it's another way to show what I am trying to do. Probably it's not ready to be merged but it works. Before this hack I tried to leverage the @RomanTsukanov [suggestion](https://github.com/surveyjs/survey-library/issues/5363#issuecomment-1363785025) but some of the questions are not easy to be reached through the `getQuestionByName` method as they may be locate inside deeply nested paneldynamic or matrixdynamic. This change will let my app users (who are the ones building the survey model) to write something like:
```
{
  "elements": [
    {
      "name": "dropdown",
      "type": "dropdown",
      "choices": [
        1,
        2,
        3,
        4
      ],
      "noneValue": "NA",
      "showNoneItem": true
    },
    {
      "name": "dropdownChoicesByUrl",
      "type": "dropdown",
      "noneValue": "N/A",
      "choicesByUrl": {
        "url": "https://restcountries.com/v2/all",
        "valueName": "name"
      },
      "showNoneItem": true
    }
  ]
}
```
PS. I found many bugs over the last years but this is my first PR. Please be patient! thank you