### PR TITLE
redirect conditional display

### DIFF
--- a/docs/uri.json
+++ b/docs/uri.json
@@ -4,6 +4,7 @@
   ],
   "rename": {
     "design-survey-question-titles": "design-survey-configure-question-titles",
+    "design-survey-conditional-display": "design-survey-conditional-logic",
     "design-survey-predefine-answers": "design-survey-pre-populate-form-fields",
     "localization": "survey-localization"
   },


### PR DESCRIPTION
> those two have identical title error:
> https://surveyjs.io/form-library/documentation/overview
> https://surveyjs.io/form-library/documentation/design-survey/conditional-display
> The second one has a redirect to /documentation. Is it wrong? There is a page https://surveyjs.io/form-library/documentation/design-survey/conditional-logic that I guess is a better match for this broken URL.

see https://github.com/surveyjs/service/issues/751