### PR TITLE
Fixed https://github.com/surveyjs/survey-creator/issues/3784 - Text Questions - Property Grid doesn't show the min andmax properties for the range input type

### DIFF
--- a/src/question_text.ts
+++ b/src/question_text.ts
@@ -447,6 +447,7 @@ export class QuestionTextModel extends QuestionTextBase {
 
 const minMaxTypes = [
   "number",
+  "range",
   "date",
   "datetime",
   "datetime-local",
@@ -537,7 +538,7 @@ Serializer.addClass(
       },
       onPropertyEditorUpdate: function(obj: any, propertyEditor: any) {
         if(!!obj && !!obj.inputType) {
-          propertyEditor.inputType = obj.inputType;
+          propertyEditor.inputType = obj.inputType !== "range" ? obj.inputType : "number";
         }
       },
       onSettingValue: (obj: any, val: any): any => {
@@ -556,7 +557,7 @@ Serializer.addClass(
       },
       onPropertyEditorUpdate: function(obj: any, propertyEditor: any) {
         if(!!obj && !!obj.inputType) {
-          propertyEditor.inputType = obj.inputType;
+          propertyEditor.inputType = obj.inputType !== "range" ? obj.inputType : "number";
         }
       },
     },
@@ -597,7 +598,7 @@ Serializer.addClass(
       dependsOn: "inputType",
       visibleIf: function(obj: any) {
         if (!obj) return false;
-        return obj.inputType === "number";
+        return obj.inputType === "number" || obj.inputType === "range";
       },
     },
     {

--- a/tests/surveyquestiontests.ts
+++ b/tests/surveyquestiontests.ts
@@ -6148,9 +6148,23 @@ QUnit.test("QuestionTextModel isMinMaxType", function (assert) {
   assert.equal(q1.inputType, "text");
   assert.equal(q1.isMinMaxType, false);
   q1.inputType = "range";
-  assert.equal(q1.isMinMaxType, false);
+  assert.equal(q1.isMinMaxType, true);
   q1.inputType = "datetime";
   assert.equal(q1.isMinMaxType, true);
+  q1.inputType = "tel";
+  assert.equal(q1.isMinMaxType, false);
+});
+QUnit.test("QuestionTextModel range min/max property editor type", function (assert) {
+  const minProperty = Serializer.findProperty("text", "min");
+  const maxProperty = Serializer.findProperty("text", "max");
+  const q1 = new QuestionTextModel("q1");
+  q1.inputType = "range";
+  const minJson = { inputType: "text" };
+  minProperty.onPropertyEditorUpdate(q1, minJson);
+  assert.equal(minJson.inputType, "number");
+  const maxJson = { inputType: "text" };
+  minProperty.onPropertyEditorUpdate(q1, maxJson);
+  assert.equal(maxJson.inputType, "number");
 });
 QUnit.test("QuestionTextModel inputStyle for empty inputWidth - https://github.com/surveyjs/survey-creator/issues/3755", function (assert) {
   const q1 = new QuestionTextModel("q1");


### PR DESCRIPTION
https://github.com/surveyjs/survey-creator/issues/3784