### PR TITLE
implement locale fallback for all locales

### DIFF
--- a/src/surveyStrings.ts
+++ b/src/surveyStrings.ts
@@ -23,27 +23,23 @@ export var surveyLocalization = {
   getLocaleStrings(loc: string): any {
     return this.locales[loc];
   },
-  getCurrentStrings(locale?: string): any {
-    let loc = locale && this.locales[locale];
-    if (!loc) loc = this.currentLocale ? this.locales[this.currentLocale] : this.locales[this.defaultLocale];
-    if (!loc) loc = this.locales[this.defaultLocale];
-    if (!loc) loc = this.locales["en"];
-    return loc;
-  },
-  getString: function (strName: string, locale: string = null) {
-    const originalLocale = locale;
-    locale = locale || this.currentLocale || this.defaultLocale;
-    var loc = this.getCurrentStrings(locale);
-    if (!!loc[strName]) return loc[strName];
-    const index = !!locale ? locale.indexOf("-") : -1;
-    if(index > -1) return this.getString(strName, locale.substring(0, index));
-    loc = this.locales[this.defaultLocale];
-    var result = loc[strName];
-    if (result === undefined) {
-      result = this.locales["en"][strName];
+  getString: function (strName: string, requestedLocale: string = null) {
+    const rawOptions = [requestedLocale, this.currentLocale, this.defaultLocale, "en"]
+
+    for (let locale of rawOptions) {
+      if (!!locale) {
+        // Try exact locale
+        if (!!this.locales?.[locale]?.[strName]) {
+          return this.locales[locale][strName]
+        }
+        // Try parent locale
+        const parts = locale.split('-')
+        if (parts.length > 1 && !!this.locales?.[parts[0]]?.[strName]) {
+          return this.locales[parts[0]][strName]
+        }
+      }
     }
-    if(result === undefined) return this.onGetExternalString(strName, originalLocale);
-    return result;
+    return this.onGetExternalString(strName, requestedLocale);
   },
   getLocales: function (removeDefaultLoc: boolean = false): Array<string> {
     var res = [];

--- a/src/surveyStrings.ts
+++ b/src/surveyStrings.ts
@@ -24,18 +24,18 @@ export var surveyLocalization = {
     return this.locales[loc];
   },
   getString: function (strName: string, requestedLocale: string = null) {
-    const rawOptions = [requestedLocale, this.currentLocale, this.defaultLocale, "en"]
+    const rawOptions = [requestedLocale, this.currentLocale, this.defaultLocale, "en"];
 
     for (let locale of rawOptions) {
       if (!!locale) {
         // Try exact locale
         if (!!this.locales?.[locale]?.[strName]) {
-          return this.locales[locale][strName]
+          return this.locales[locale][strName];
         }
         // Try parent locale
-        const parts = locale.split('-')
+        const parts = locale.split("-");
         if (parts.length > 1 && !!this.locales?.[parts[0]]?.[strName]) {
-          return this.locales[parts[0]][strName]
+          return this.locales[parts[0]][strName];
         }
       }
     }


### PR DESCRIPTION
This implements language fallbacks in a more generic approach.

Instead of picking the locale string collection at the start, we try the locales and their fallbacks in order searching for a specific string.

The goal is to allow supporting custom locales more easily:

- [ ] Setting a survey locale to `nl-something`, which is unknown would result in strings from the `nl` translations.
- [ ] Allow overriding just a single string for a locale, while other strings are taken from the base locale in a cascading fashion



The idea is that instead of picking a whole locale dictionary at the start, we just define all possible locales.
Imagine this situation:
```
defaultLocale = "en-US"
currentLocale = "de-DE"
requestedLocale = "nl-test"
requestedMessage= "otherItemText"
```
In the current version, requesting an unknown language will just use the `currentLocale`, and if that doesn't exist use the `defaultLocale`.
This PR changes this behavior to be more granular. It will check each dictionary:
1. Check `this.locales["nl-test"]` if found return
2. Check `this.locales["nl"]` if found return
3. Check `this.locales["de-DE"]` if found return
4. Check `this.locales["de"]` if found return
5. Check `this.locales["en-US"]` if found return
6. Check `this.locales["en"]` if found return
7. If not found call `this.onGetExternalString(...)`

Marking as a draft so we can discuss the implementation. Tests still pass even though the implementation and behavior changed, this means that the tests were not thorough enough to detect this change in behavior.

