### PR TITLE
chore: improve typing by introducing OptionalCallback

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -6,6 +6,7 @@ import { IListModel, ListModel } from "../list";
 import { IPopupOptionsBase, PopupModel } from "../popup";
 import { CssClassBuilder } from "../utils/cssClassBuilder";
 import { defaultActionBarCss } from "./container";
+import { OptionalCallback } from "src/base-interfaces";
 
 export type actionModeType = "large" | "small" | "popup";
 
@@ -287,7 +288,7 @@ export abstract class BaseAction extends Base implements IAction {
 
 export class Action extends BaseAction implements IAction, ILocalizableOwner {
   private locTitleValue: LocalizableString;
-  public updateCallback: () => void;
+  public updateCallback: OptionalCallback;
   private raiseUpdate() {
     this.updateCallback && this.updateCallback();
   }

--- a/src/base-interfaces.ts
+++ b/src/base-interfaces.ts
@@ -345,6 +345,8 @@ export interface IFindElement {
 
 export type LayoutElementContainer = "header" | "footer" | "left" | "right" | "contentTop" | "contentBottom";
 
+export type OptionalCallback = null | (() => void);
+
 export interface ISurveyLayoutElement {
   id: string;
   container?: LayoutElementContainer | Array<LayoutElementContainer>;

--- a/src/base.ts
+++ b/src/base.ts
@@ -9,7 +9,7 @@ import {
 } from "./jsonobject";
 import { settings } from "./settings";
 import { ItemValue } from "./itemvalue";
-import { IElement, IFindElement, IProgressInfo, ISurvey } from "./base-interfaces";
+import { IElement, IFindElement, IProgressInfo, ISurvey, OptionalCallback } from "./base-interfaces";
 import { ExpressionRunner } from "./conditions";
 import { surveyLocalization } from "./surveyStrings";
 
@@ -285,7 +285,7 @@ export class Base {
     val: any
   ) => void;
   createArrayCoreHandler: (propertiesHash: any, name: string) => Array<any>;
-  surveyChangedCallback: () => void;
+  surveyChangedCallback: OptionalCallback;
 
   private isCreating = true;
 
@@ -1087,7 +1087,7 @@ export class ArrayChanges {
 }
 
 export class Event<CallbackFunction extends Function, Sender, Options> {
-  public onCallbacksChanged: () => void;
+  public onCallbacksChanged: OptionalCallback;
   protected callbacks: Array<CallbackFunction>;
   public get isEmpty(): boolean {
     return this.length === 0;

--- a/src/choicesRestful.ts
+++ b/src/choicesRestful.ts
@@ -1,5 +1,5 @@
 import { Base } from "./base";
-import { ITextProcessor, IQuestion, ISurvey } from "./base-interfaces";
+import { ITextProcessor, IQuestion, ISurvey, OptionalCallback } from "./base-interfaces";
 import { ItemValue } from "./itemvalue";
 import { Serializer, JsonObjectProperty } from "./jsonobject";
 import { WebRequestError, WebRequestEmptyError } from "./error";
@@ -123,7 +123,7 @@ export class ChoicesRestful extends Base {
   private isUsingCacheFromUrl: boolean = undefined;
   public onProcessedUrlCallback: (url: string, path: string) => void;
   public getResultCallback: (items: Array<ItemValue>) => void;
-  public beforeSendRequestCallback: () => void;
+  public beforeSendRequestCallback: OptionalCallback;
   public updateResultCallback: (
     items: Array<ItemValue>,
     serverResult: any

--- a/src/flowpanel.ts
+++ b/src/flowpanel.ts
@@ -1,5 +1,5 @@
 import { Serializer } from "./jsonobject";
-import { IElement, IQuestion } from "./base-interfaces";
+import { IElement, IQuestion, OptionalCallback } from "./base-interfaces";
 import { PanelModel } from "./panel";
 import { LocalizableString } from "./localizablestring";
 import { Question } from "./question";
@@ -10,7 +10,7 @@ import { Question } from "./question";
  */
 export class FlowPanelModel extends PanelModel {
   static contentElementNamePrefix = "element:";
-  public contentChangedCallback: () => void;
+  public contentChangedCallback: OptionalCallback;
   public onGetHtmlForQuestion: (question: Question) => string;
   public onCustomHtmlProducing: () => string;
   constructor(name: string = "") {

--- a/src/itemvalue.ts
+++ b/src/itemvalue.ts
@@ -36,6 +36,19 @@ export class ItemValue extends BaseAction implements ILocalizableOwner, IShortcu
     return this.locOwner ? this.locOwner.getProcessedText(text) : text;
   }
 
+  private _isExclusive: boolean;
+  public get isExclusive(): boolean {
+    return this._isExclusive
+  }
+
+  public set isExclusive(value: boolean) {
+    this._isExclusive = value
+  }
+
+  public isFixedPosition(): boolean {
+    return false
+  }
+
   public static get Separator() {
     return settings.itemValueSeparator;
   }
@@ -193,10 +206,12 @@ export class ItemValue extends BaseAction implements ILocalizableOwner, IShortcu
   constructor(
     value: any,
     text: string = null,
-    protected typeName = "itemvalue"
+    protected typeName = "itemvalue",
+    isExclusive: boolean = false
   ) {
     super();
     this.locTextValue = new LocalizableString(this, true, "text");
+    this.isExclusive = isExclusive;
     this.locTextValue.onStrChanged = (oldValue: string, newValue: string) => {
       if (newValue == this.value) {
         newValue = undefined;
@@ -447,14 +462,14 @@ export class ItemValue extends BaseAction implements ILocalizableOwner, IShortcu
   @property() icon: string;
 }
 
-Base.createItemValue = function (source: any, type?: string): any {
+Base.createItemValue = function (source: any, type?: string, isExclusive: boolean = false): any {
   var item = null;
   if (!!type) {
     item = JsonObject.metaData.createClass(type, {});
   } else if (typeof source.getType === "function") {
-    item = new ItemValue(null, undefined, source.getType());
+    item = new ItemValue(null, undefined, source.getType(), isExclusive);
   } else {
-    item = new ItemValue(null);
+    item = new ItemValue(null, null, null, isExclusive);
   }
   item.setData(source);
   return item;

--- a/src/localizablestring.ts
+++ b/src/localizablestring.ts
@@ -2,6 +2,7 @@ import { Helpers } from "./helpers";
 import { surveyLocalization } from "./surveyStrings";
 import { settings } from "./settings";
 import { EventBase } from "./base";
+import { OptionalCallback } from "./base-interfaces";
 
 export interface ILocalizableOwner {
   getLocale(): string;
@@ -41,7 +42,7 @@ export class LocalizableString implements ILocalizableString {
   public storeDefaultText: boolean;
   public onGetLocalizationTextCallback: (str: string) => string;
   public onStrChanged: (oldValue: string, newValue: string) => void;
-  public onSearchChanged: () => void;
+  public onSearchChanged: OptionalCallback;
   public sharedData: LocalizableString;
   public searchText: string;
   public searchIndex: number;

--- a/src/martixBase.ts
+++ b/src/martixBase.ts
@@ -5,6 +5,7 @@ import { property, Serializer } from "./jsonobject";
 import { ConditionRunner } from "./conditions";
 import { Helpers } from "./helpers";
 import { CssClassBuilder } from "./utils/cssClassBuilder";
+import { OptionalCallback } from "./base-interfaces";
 
 /**
  * A base class for all matrix question types.
@@ -14,7 +15,7 @@ export class QuestionMatrixBaseModel<TRow, TColumn> extends Question {
   protected filteredRows: Array<ItemValue>;
   protected generatedVisibleRows: Array<TRow> = null;
   protected generatedTotalRow: TRow = null;
-  public visibleRowsChangedCallback: () => void;
+  public visibleRowsChangedCallback: OptionalCallback;
 
   protected createColumnValues(): any {
     return this.createItemValues("columns");

--- a/src/popup-survey.ts
+++ b/src/popup-survey.ts
@@ -2,6 +2,7 @@ import { Base, ComputedUpdater } from "./base";
 import { SurveyModel } from "./survey";
 import { LocalizableString } from "./localizablestring";
 import { property } from "./jsonobject";
+import { OptionalCallback } from "./base-interfaces";
 
 /**
  * A Model for a survey running in the Popup Window.
@@ -13,8 +14,8 @@ export class PopupSurveyModel extends Base {
   windowElement: HTMLDivElement;
 
   templateValue: string;
-  expandedChangedCallback: () => void;
-  showingChangedCallback: () => void;
+  expandedChangedCallback: OptionalCallback;
+  showingChangedCallback: OptionalCallback;
 
   constructor(jsonObj: any, initialModel: SurveyModel = null) {
     super();

--- a/src/question.ts
+++ b/src/question.ts
@@ -1,7 +1,7 @@
 import { HashTable, Helpers } from "./helpers";
 import { JsonObject, Serializer, property } from "./jsonobject";
 import { Base, EventBase } from "./base";
-import { IElement, IQuestion, IPanel, IConditionRunner, ISurveyImpl, IPage, ITitleOwner, IProgressInfo, ISurvey } from "./base-interfaces";
+import { IElement, IQuestion, IPanel, IConditionRunner, ISurveyImpl, IPage, ITitleOwner, IProgressInfo, ISurvey, OptionalCallback } from "./base-interfaces";
 import { SurveyElement } from "./survey-element";
 import { surveyLocalization } from "./surveyStrings";
 import { AnswerRequiredError, CustomError } from "./error";
@@ -56,16 +56,16 @@ export class Question extends SurveyElement<Question>
   private isCustomWidgetRequested: boolean;
   private customWidgetValue: QuestionCustomWidget;
   customWidgetData = { isNeedRender: true };
-  focusCallback: () => void;
-  surveyLoadCallback: () => void;
+  focusCallback: OptionalCallback;
+  surveyLoadCallback: OptionalCallback;
   displayValueCallback: (text: string) => string;
 
   private defaultValueRunner: ExpressionRunner;
   private isChangingViaDefaultValue: boolean;
   private isValueChangedDirectly: boolean;
-  valueChangedCallback: () => void;
-  commentChangedCallback: () => void;
-  localeChangedCallback: () => void;
+  valueChangedCallback: OptionalCallback;
+  commentChangedCallback: OptionalCallback;
+  localeChangedCallback: OptionalCallback;
   validateValueCallback: () => SurveyError;
   questionTitleTemplateCallback: () => string;
   afterRenderQuestionCallback: (question: Question, element: any) => any;
@@ -971,7 +971,7 @@ export class Question extends SurveyElement<Question>
     if(!this.survey) return;
     (this.survey as SurveyModel).whenQuestionFocusIn(this);
   }
-  protected fireCallback(callback: () => void): void {
+  protected fireCallback(callback: OptionalCallback): void {
     if (callback) callback();
   }
   public getOthersMaxLength(): any {
@@ -2049,7 +2049,7 @@ export class Question extends SurveyElement<Question>
     this.onMobileChangedCallback && this.onMobileChangedCallback();
   }
 
-  private onMobileChangedCallback: () => void;
+  private onMobileChangedCallback: OptionalCallback;
 
   private initResponsiveness(el: HTMLElement) {
     this.destroyResizeObserver();

--- a/src/question_baseselect.ts
+++ b/src/question_baseselect.ts
@@ -1,6 +1,6 @@
 import { property, Serializer } from "./jsonobject";
 import { SurveyError } from "./survey-error";
-import { ISurveyImpl, ISurvey } from "./base-interfaces";
+import { ISurveyImpl, ISurvey, OptionalCallback } from "./base-interfaces";
 import { SurveyModel } from "./survey";
 import { Question } from "./question";
 import { ItemValue } from "./itemvalue";
@@ -18,8 +18,8 @@ import { mergeValues } from "./utils/utils";
  * A base class for multiple-choice question types ([Checkbox](https://surveyjs.io/form-library/documentation/questioncheckboxmodel), [Dropdown](https://surveyjs.io/form-library/documentation/questiondropdownmodel), [Radiogroup](https://surveyjs.io/form-library/documentation/questionradiogroupmodel), etc.).
  */
 export class QuestionSelectBase extends Question {
-  public visibleChoicesChangedCallback: () => void;
-  public loadedChoicesFromServerCallback: () => void;
+  public visibleChoicesChangedCallback: OptionalCallback;
+  public loadedChoicesFromServerCallback: OptionalCallback;
   private filteredChoicesValue: Array<ItemValue>;
   private conditionChoicesVisibleIfRunner: ConditionRunner;
   private conditionChoicesEnableIfRunner: ConditionRunner;
@@ -30,7 +30,7 @@ export class QuestionSelectBase extends Question {
   private isChoicesLoaded: boolean;
   private enableOnLoadingChoices: boolean;
   private dependedQuestions: Array<QuestionSelectBase> = [];
-  private noneItemValue: ItemValue = new ItemValue(settings.noneItemValue);
+  private noneItemValue: ItemValue = new ItemValue(settings.noneItemValue, null, null, true);
   private newItemValue: ItemValue;
   private canShowOptionItemCallback: (item: ItemValue) => boolean;
   private isUsingCarrayForward: boolean;
@@ -585,7 +585,7 @@ export class QuestionSelectBase extends Question {
   /**
    * If the clearIncorrectValuesCallback is set, it is used to clear incorrect values instead of default behaviour.
    */
-  public clearIncorrectValuesCallback: () => void;
+  public clearIncorrectValuesCallback: OptionalCallback;
   /**
    * Configures access to a RESTful service that returns choice items. Refer to the [ChoicesRestful](https://surveyjs.io/form-library/documentation/choicesrestful) class description for more information.
    *
@@ -1622,7 +1622,7 @@ export class QuestionSelectBase extends Question {
  * A base class for multiple-selection question types that can display choice items in multiple columns ([Checkbox](https://surveyjs.io/form-library/documentation/questioncheckboxmodel), [Radiogroup](https://surveyjs.io/form-library/documentation/questionradiogroupmodel), [Image Picker](https://surveyjs.io/form-library/documentation/questionimagepickermodel)).
  */
 export class QuestionCheckboxBase extends QuestionSelectBase {
-  colCountChangedCallback: () => void;
+  colCountChangedCallback: OptionalCallback;
   constructor(name: string) {
     super(name);
   }

--- a/src/question_matrix.ts
+++ b/src/question_matrix.ts
@@ -13,6 +13,7 @@ import { IConditionObject } from "./question";
 import { settings } from "./settings";
 import { SurveyModel } from "./survey";
 import { CssClassBuilder } from "./utils/cssClassBuilder";
+import { OptionalCallback } from "./base-interfaces";
 
 export interface IMatrixData {
   onMatrixRowChanged(row: MatrixRowModel): void;
@@ -77,7 +78,7 @@ export class MatrixCells {
   public get isEmpty(): boolean {
     return Object.keys(this.values).length == 0;
   }
-  public onValuesChanged: () => void;
+  public onValuesChanged: OptionalCallback;
   private valuesChanged(): void {
     if(!!this.onValuesChanged) {
       this.onValuesChanged();

--- a/src/question_matrixdropdownbase.ts
+++ b/src/question_matrixdropdownbase.ts
@@ -3,7 +3,7 @@ import { QuestionMatrixBaseModel } from "./martixBase";
 import { Question, IConditionObject } from "./question";
 import { HashTable, Helpers } from "./helpers";
 import { Base } from "./base";
-import { IElement, IQuestion, ISurveyData, ISurvey, ISurveyImpl, ITextProcessor, IProgressInfo, IPanel } from "./base-interfaces";
+import { IElement, IQuestion, ISurveyData, ISurvey, ISurveyImpl, ITextProcessor, IProgressInfo, IPanel, OptionalCallback } from "./base-interfaces";
 import { SurveyElement } from "./survey-element";
 import { TextPreProcessorValue, QuestionTextProcessor } from "./textPreProcessor";
 import { ItemValue } from "./itemvalue";
@@ -212,7 +212,7 @@ implements ISurveyData, ISurveyImpl, ILocalizableOwner {
 
   public cells: Array<MatrixDropdownCell> = [];
   public showHideDetailPanelClick: any;
-  public onDetailPanelShowingChanged: () => void;
+  public onDetailPanelShowingChanged: OptionalCallback;
 
   constructor(data: IMatrixDropdownData, value: any) {
     this.data = data;
@@ -619,7 +619,7 @@ implements ISurveyData, ISurveyImpl, ILocalizableOwner {
   public hasErrors(
     fireCallback: boolean,
     rec: any,
-    raiseOnCompletedAsyncValidators: () => void
+    raiseOnCompletedAsyncValidators: OptionalCallback
   ): boolean {
     var res = false;
     var cells = this.cells;
@@ -792,8 +792,8 @@ export class QuestionMatrixDropdownModelBase extends QuestionMatrixBaseModel<Mat
   private detailPanelValue: PanelModel;
   private isUniqueCaseSensitiveValue: boolean;
   protected isRowChanging = false;
-  columnsChangedCallback: () => void;
-  onRenderedTableResetCallback: () => void;
+  columnsChangedCallback: OptionalCallback;
+  onRenderedTableResetCallback: OptionalCallback;
   onRenderedTableCreatedCallback: (
     table: QuestionMatrixDropdownRenderedTable
   ) => void;

--- a/src/question_multipletext.ts
+++ b/src/question_multipletext.ts
@@ -7,7 +7,8 @@ import {
   IElement,
   IQuestion,
   ITextProcessor,
-  IProgressInfo
+  IProgressInfo,
+  OptionalCallback
 } from "./base-interfaces";
 import { SurveyElement } from "./survey-element";
 import { SurveyValidator, IValidatorOwner } from "./validator";
@@ -296,7 +297,7 @@ export class QuestionMultipleTextModel extends Question
     for (var i = 0; i < names.length; i++) question.addItem(names[i]);
   }
 
-  colCountChangedCallback: () => void;
+  colCountChangedCallback: OptionalCallback;
   constructor(name: string) {
     super(name);
     this.createNewArray("items", (item: any) => {

--- a/src/question_paneldynamic.ts
+++ b/src/question_paneldynamic.ts
@@ -9,6 +9,7 @@ import {
   ISurveyImpl,
   ITextProcessor,
   IProgressInfo,
+  OptionalCallback,
 } from "./base-interfaces";
 import { SurveyElement } from "./survey-element";
 import { surveyLocalization } from "./surveyStrings";
@@ -234,9 +235,9 @@ export class QuestionPanelDynamicModel extends Question
   private isValueChangingInternally: boolean;
   private changingValueQuestion: Question;
 
-  renderModeChangedCallback: () => void;
-  panelCountChangedCallback: () => void;
-  currentIndexChangedCallback: () => void;
+  renderModeChangedCallback: OptionalCallback;
+  panelCountChangedCallback: OptionalCallback;
+  currentIndexChangedCallback: OptionalCallback;
 
   constructor(name: string) {
     super(name);

--- a/src/survey-element.ts
+++ b/src/survey-element.ts
@@ -13,7 +13,8 @@ import {
   ISurveyData,
   ISurveyImpl,
   ITextProcessor,
-  ITitleOwner
+  ITitleOwner,
+  OptionalCallback
 } from "./base-interfaces";
 import { SurveyError } from "./survey-error";
 import { Helpers } from "./helpers";
@@ -119,7 +120,7 @@ export enum DragTypeOverMeEnum {
  * A base class for all survey elements.
  */
 export class SurveyElement<E = any> extends SurveyElementCore implements ISurveyElement {
-  stateChangedCallback: () => void;
+  stateChangedCallback: OptionalCallback;
 
   public static getProgressInfoByElements(
     children: Array<SurveyElement>,
@@ -151,7 +152,7 @@ export class SurveyElement<E = any> extends SurveyElementCore implements ISurvey
   @property({ defaultValue: null }) dragTypeOverMe: DragTypeOverMeEnum;
   @property({ defaultValue: false }) isDragMe: boolean;
 
-  public readOnlyChangedCallback: () => void;
+  public readOnlyChangedCallback: OptionalCallback;
 
   public static ScrollElementToTop(elementId: string): boolean {
     if (!elementId || typeof document === "undefined") return false;

--- a/src/survey.ts
+++ b/src/survey.ts
@@ -15,7 +15,8 @@ import {
   IProgressInfo,
   IFindElement,
   ISurveyLayoutElement,
-  LayoutElementContainer
+  LayoutElementContainer,
+  OptionalCallback
 } from "./base-interfaces";
 import { SurveyElementCore, SurveyElement } from "./survey-element";
 import { surveyCss } from "./defaultCss/defaultV2Css";
@@ -975,7 +976,7 @@ export class SurveyModel extends SurveyElementCore
   public get pages(): Array<PageModel> {
     return this.getPropertyValue("pages");
   }
-  renderCallback: () => void;
+  renderCallback: OptionalCallback;
   public render(element: any = null): void {
     if (this.renderCallback) {
       this.renderCallback();
@@ -6886,7 +6887,7 @@ export class SurveyModel extends SurveyElementCore
       this.disposeCallback();
     }
   }
-  disposeCallback: () => void;
+  disposeCallback: OptionalCallback;
 }
 
 function isStrCiEqual(a: string, b: string) {


### PR DESCRIPTION
We're moving to a more typescript based survey runner.
This means we're now importing library types and our typescript checkers are running into errors.

This change introduced a new type `OptionalCallback` and uses it for callbacks that are optional. Currently these are incorrectly typed in the library code.

For example this snippet from `survey.ts:
```ts
{ 
 // other stuff ommitted for brevity
  /**
   * Use this method to dispose survey model properly.
   */
  public dispose() {
    this.currentPage = null;
    this.destroyResizeObserver();
    super.dispose();
    this.editingObj = null;
    if (!this.pages) return;
    for (var i = 0; i < this.pages.length; i++) {
      this.pages[i].setSurveyImpl(undefined);
      this.pages[i].dispose();
    }
    this.pages.splice(0, this.pages.length);
    if (this.disposeCallback) {
      this.disposeCallback();
    }
  }
  disposeCallback: () => void;
```

The type definition does not permit `null` for `disposeCallback` however, as can be seen in the line above, a truthy-check is done and `null` will actually work as expected.

We noted this when doing things like removing callbacks in the `willUnmount` function of a custom widget. The compiler would tell us that assigning `null` to `question.readOnlyChangedCallback` is not valid. 
