### PR TITLE
#6072 Dropdown with Lazy Loading - The entered text overrides the input value and the item looses the display text

### DIFF
--- a/src/dropdownListModel.ts
+++ b/src/dropdownListModel.ts
@@ -370,10 +370,10 @@ export class DropdownListModel extends Base {
     }
     this.scrollToFocusedItem();
     if (this.question.value && !this.listModel.filterString && this.question.searchEnabled && this.question instanceof QuestionDropdownModel) {
-      this.applyInputString(this.listModel.focusedItem);
+      this.applyInputString(this.listModel.focusedItem || this.question.selectedItem);
     }
     else {
-      this.applyHintString(this.listModel.focusedItem);
+      this.applyHintString(this.listModel.focusedItem || this.question.selectedItem);
     }
 
     this.ariaActivedescendant = this.listModel.focusedItem?.elementId;

--- a/tests/questionDropdownTests.ts
+++ b/tests/questionDropdownTests.ts
@@ -558,7 +558,7 @@ QUnit.test("hasScroll property", assert => {
   document.body.removeChild(element);
 });
 
-function getNumberArray(skip = 1, count = 25, filter = ""): Array<number> {
+function getNumberArray(skip = 1, count = 25, filter = ""): Array<any> {
   const result: Array<number> = [];
   let index = skip;
   while ((skip + result.length) < (skip + count)) {
@@ -608,6 +608,32 @@ QUnit.test("lazy loading: first loading", assert => {
     assert.equal(question.choices.length, 30);
     assert.equal(question.choices[0].value, 1);
     assert.equal(question.choices[29].value, 30);
+    done();
+  }, 550);
+});
+
+QUnit.test("lazy loading: first loading - default value", assert => {
+  const done = assert.async();
+  const json = {
+    questions: [{
+      "type": "dropdown",
+      "name": "q1",
+      "defaultValue": "1",
+      "choicesLazyLoadEnabled": true,
+      "choicesLazyLoadPageSize": 30,
+    }]
+  };
+  const survey = new SurveyModel(json);
+  survey.onChoicesLazyLoad.add(callback);
+
+  const question = <QuestionDropdownModel>survey.getAllQuestions()[0];
+  assert.equal(question.choicesLazyLoadEnabled, true);
+  assert.equal(question.choices.length, 0);
+  question.dropdownListModel.popupModel.isVisible = true;
+  question.dropdownListModel.changeSelectionWithKeyboard(false);
+  setTimeout(() => {
+    assert.equal(question.choices.length, 30);
+    assert.equal(question.dropdownListModel.inputStringRendered, "1");
     done();
   }, 550);
 });


### PR DESCRIPTION
Fixes #6072