### PR TITLE
fix conflicting padding rules

### DIFF
--- a/src/default-styles.scss
+++ b/src/default-styles.scss
@@ -922,7 +922,7 @@ f-panel {
   position: relative;
   align-items: center;
   margin-left: auto;
-  padding: 0 0 0 16px;
+  padding-left: 16px;
   overflow: hidden;
   white-space: nowrap;
 }

--- a/src/main.scss
+++ b/src/main.scss
@@ -877,7 +877,7 @@ body {
 
   .sv_nav {
     display: block;
-    padding: 1em 0;
+    padding-top: 1em;
     min-height: var(--base-line-height, $base-line-height);
 
     .sv_nav_btn {


### PR DESCRIPTION
We change the padding rules of both .sv_nav and .sv-action-bar so they do not conflict anymore, given they can be assigned to the same div element using the default theme.

fixes #6159