### PR TITLE
Hide "extreme values" setting for non-text rating types

### DIFF
--- a/src/question_rating.ts
+++ b/src/question_rating.ts
@@ -904,14 +904,18 @@ Serializer.addClass(
       serializationProperty: "locMaxRateDescription",
       visibleIndex: 18
     },
-    { name: "displayRateDescriptionsAsExtremeItems:boolean", default: false, visibleIndex: 19 },
+    {
+      name: "displayRateDescriptionsAsExtremeItems:boolean",
+      default: false,
+      visibleIndex: 19,
+      visibleIf: function (obj: any) {
+        return obj.rateType == "labels";
+      }
+    },
     {
       name: "displayMode",
       default: "auto",
       choices: ["auto", "buttons", "dropdown"],
-      visibleIf: function (obj: any) {
-        return obj.rateType == "labels";
-      },
       visibleIndex: 20
     }
   ],


### PR DESCRIPTION
Fixes #6214