### PR TITLE
An empty preview displays an incorrect message and doesn't allow user…

### DIFF
--- a/src/survey.ts
+++ b/src/survey.ts
@@ -3367,8 +3367,15 @@ export class SurveyModel extends SurveyElementCore
   public get areEmptyElementsHidden(): boolean {
     return (
       this.isShowingPreview &&
-      this.showPreviewBeforeComplete == "showAnsweredQuestions"
+      this.showPreviewBeforeComplete == "showAnsweredQuestions" && this.isAnyQuestionAnswered
     );
+  }
+  private get isAnyQuestionAnswered(): boolean {
+    const questions = this.getAllQuestions(true);
+    for(let i = 0; i < questions.length; i ++) {
+      if(!questions[i].isEmpty()) return true;
+    }
+    return false;
   }
   /**
    * Returns `true`, if a user has already completed the survey in this browser and there is a cookie about it. Survey goes to `completedbefore` state if the function returns `true`.

--- a/tests/surveyShowPreviewTests.ts
+++ b/tests/surveyShowPreviewTests.ts
@@ -656,3 +656,37 @@ QUnit.test(
     assert.equal(survey.state, "preview", "We are in preview mode");
   }
 );
+QUnit.test(
+  "showPreviewBeforeComplete = 'showAnsweredQuestions' and all questions are empty, Bug#6497",
+  function(assert) {
+    const survey = new SurveyModel({
+      "pages": [
+        {
+          "name": "page1",
+          "elements": [
+            {
+              "type": "radiogroup",
+              "name": "q1",
+              "choices": ["item1", "item2", "item3"]
+            }
+          ]
+        },
+        {
+          "name": "page2",
+          "elements": [
+            {
+              "type": "radiogroup",
+              "name": "q2",
+              "choices": ["item1", "item2", "item3"]
+            }
+          ]
+        }
+      ],
+      "showPreviewBeforeComplete": "showAnsweredQuestions"
+    });
+    survey.nextPage();
+    survey.showPreview();
+    assert.equal(survey.state, "preview", "There is no errors");
+    assert.equal(survey.getAllQuestions(true).length, 2, "Show all questions");
+  }
+);


### PR DESCRIPTION
…s to get back to the survey fixed #6497