### PR TITLE
fix(popup): prevent exception on Legacy Edge when opening a dropdown popup

### DIFF
--- a/src/popup-dropdown-view-model.ts
+++ b/src/popup-dropdown-view-model.ts
@@ -56,7 +56,8 @@ export class PopupDropdownViewModel extends PopupBaseViewModel {
     let actualHorizontalPosition = this.getActualHorizontalPosition();
 
     if (!!window) {
-      height = Math.ceil(Math.min(height, window.innerHeight * 0.9, window.visualViewport.height));
+      const heightValues = [height, window.innerHeight * 0.9, window.visualViewport?.height];
+      height = Math.ceil(Math.min(...heightValues.filter((each) => typeof each === "number")));
       verticalPosition = PopupUtils.updateVerticalPosition(
         targetElementRect,
         height,


### PR DESCRIPTION
Legacy Edge does not support the `VisualViewport` browser API. This causes an exception in the popup logic and breaks the UI in an unrecoverable manner. Legacy Edge also happens to be the engine which powers WinUI WebViews, which react-native-windows uses by default.