### PR TITLE
Configure Question Titles-Remove requireNumTitle

### DIFF
--- a/docs/design-survey-configure-question-titles.md
+++ b/docs/design-survey-configure-question-titles.md
@@ -60,8 +60,7 @@ You can arrange the question title, number, and required mark in different seque
 const surveyJson = {
   // ...
   "questionTitlePattern": "numTitleRequire", // 1. Question Title *
-  "questionTitlePattern": "numRequireTitle", // 1. * Question Title
-  "questionTitlePattern": "requireNumTitle", // * 1. Question Title
+  "questionTitlePattern": "numRequireTitle", // 1. * Question Title  
   "questionTitlePattern": "numTitle",        // 1. Question Title
 }
 ```


### PR DESCRIPTION
https://github.com/surveyjs/service/issues/1405

Remove requireNumTitle from the help topic: https://surveyjs.io/form-library/documentation/design-survey/configure-question-titles#title-pattern