### PR TITLE
defaultValueExpression should be ignored in case of preloaded data (1…

### DIFF
--- a/src/question.ts
+++ b/src/question.ts
@@ -2082,7 +2082,7 @@ export class Question extends SurveyElement<Question>
       newValue = this.valueFromDataCallback(newValue);
     }
     if(!this.checkIsValueCorrect(newValue)) return;
-    this.isChangingViaDefaultValue = true;
+    this.isChangingViaDefaultValue = this.isValueEmpty(newValue);
     this.setQuestionValue(this.valueFromData(newValue));
     this.isChangingViaDefaultValue = false;
     this.updateDependedQuestions();

--- a/tests/surveytests.ts
+++ b/tests/surveytests.ts
@@ -17675,3 +17675,16 @@ QUnit.test("Copy panel with invisible questions at design-time", (assert): any =
   assert.equal(q3.isVisible, true, "q3.isVisible = true");
   assert.equal(q3.getPropertyValue("isVisible"), true, "q3.isVisible via getPropertyValue");
 });
+QUnit.test("Use variables as default values in expression", function (assert) {
+  const survey = new SurveyModel({
+    elements: [
+      {
+        type: "text",
+        name: "q1",
+        defaultValueExpression: "1",
+      }]
+  });
+  survey.data = { q1: 2 };
+  const q1 = survey.getQuestionByName("q1");
+  assert.equal(q1.value, 2, "Get data from survey");
+});


### PR DESCRIPTION
….9.107 regression) fix #6941