### PR TITLE
#7011 Weird symbols in question titles

### DIFF
--- a/src/defaultCss/defaultV2Css.ts
+++ b/src/defaultCss/defaultV2Css.ts
@@ -168,6 +168,7 @@ export var defaultV2Css = {
     titleNumInline: "sd-element__title--num-inline",
     titleLeftRoot: "sd-question--left",
     titleOnAnswer: "sd-question__title--answer",
+    titleEmpty: "sd-question__title--empty",
     titleOnError: "sd-question__title--error",
     title: "sd-title sd-element__title sd-question__title",
     titleExpandable: "sd-element__title--expandable",

--- a/src/defaultV2-theme/blocks/sd-element.scss
+++ b/src/defaultV2-theme/blocks/sd-element.scss
@@ -59,8 +59,8 @@
   .sv-string-viewer {
     white-space: normal;
 
-    &::before {
-      content: "\200B";
+    &:empty::before {
+        content: " ";
     }
   }
 }

--- a/src/defaultV2-theme/blocks/sd-element.scss
+++ b/src/defaultV2-theme/blocks/sd-element.scss
@@ -58,10 +58,6 @@
 
   .sv-string-viewer {
     white-space: normal;
-
-    &:empty::before {
-        content: " ";
-    }
   }
 }
 

--- a/src/defaultV2-theme/blocks/sd-question.scss
+++ b/src/defaultV2-theme/blocks/sd-question.scss
@@ -185,3 +185,9 @@
   overflow: visible;
   max-width: 100%;
 }
+.sd-question__title--empty {
+  .sv-string-viewer {
+    display: inline-block;
+    height: calcSize(3);
+  }
+}

--- a/src/question.ts
+++ b/src/question.ts
@@ -945,6 +945,7 @@ export class Question extends SurveyElement<Question>
     return new CssClassBuilder()
       .append(super.getCssTitle(cssClasses))
       .append(cssClasses.titleOnAnswer, !this.containsErrors && this.isAnswered)
+      .append(cssClasses.titleEmpty, !this.title.trim())
       .toString();
   }
   public get cssDescription(): string {


### PR DESCRIPTION
Fixes #7011
The bug is hard to reproduce. But it seems that the problem is with `\200b` symbol added to title https://stackoverflow.com/questions/28316938/200b-200b-weird-sign-in-string-how-to-remove-it

I got rid of this symbol and just set string `display: inline-block` and `height` for empty titles.