### PR TITLE
add headerRoot & bodyRoot to page

### DIFF
--- a/src/defaultCss/defaultV2Css.ts
+++ b/src/defaultCss/defaultV2Css.ts
@@ -147,8 +147,10 @@ export var defaultV2Css = {
   page: {
     root: "sd-page sd-body__page",
     emptyHeaderRoot: "sd-page__empty-header",
+    headerRoot: "sd-page__header",
     title: "sd-title sd-page__title",
-    description: "sd-description sd-page__description"
+    description: "sd-description sd-page__description",
+    bodyRoot: "sd-page__body",
   },
   pageTitle: "sd-title sd-page__title",
   pageDescription: "sd-description sd-page__description",

--- a/src/react/page.tsx
+++ b/src/react/page.tsx
@@ -20,10 +20,14 @@ export class SurveyPage extends SurveyPanelBase {
     var rows = this.renderRows(this.panelBase.cssClasses);
     return (
       <div ref={this.rootRef} className={this.page.cssRoot}>
-        {title}
-        {description}
-        {rows}
-      </div >
+        <div className={this.panelBase.cssClasses.page.headerRoot}>
+          {title}
+          {description}
+        </div>
+        <div className={this.panelBase.cssClasses.page.bodyRoot}>
+          {rows}
+        </div>
+      </div>
     );
   }
   protected renderTitle(): JSX.Element {


### PR DESCRIPTION
wrap the page header and body in div with classNames to allow for more css control over layout.  Allows for sticky page header or to use flex on large screens to 'split' the screen with page header to the left and questions to the right.