### PR TITLE
Fixed file question properties visibility

### DIFF
--- a/src/question_file.ts
+++ b/src/question_file.ts
@@ -989,7 +989,14 @@ Serializer.addClass(
     { name: "showCommentArea:switch", layout: "row", visible: true, category: "general" },
     { name: "showPreview:boolean", default: true },
     "allowMultiple:boolean",
-    { name: "allowImagesPreview:boolean", default: true },
+    {
+      name: "allowImagesPreview:boolean",
+      default: true,
+      dependsOn: "showPreview",
+      visibleIf: (obj: any) => {
+        return !!obj.showPreview;
+      },
+    },
     "imageHeight",
     "imageWidth",
     "acceptedTypes",
@@ -1000,7 +1007,7 @@ Serializer.addClass(
     { name: "correctAnswer", visible: false },
     { name: "validators", visible: false },
     { name: "needConfirmRemoveFile:boolean" },
-    { name: "allowCameraAccess:switch", category: "general" },
+    { name: "allowCameraAccess:switch", category: "general", visible: false },
     { name: "sourceType", choices: ["file", "camera", "file-camera"], default: "file", category: "general", visible: true }
   ],
   function () {

--- a/tests/questionFileTests.ts
+++ b/tests/questionFileTests.ts
@@ -1683,3 +1683,14 @@ QUnit.test("QuestionFile check renderedPlaceholder in different modes", function
   q1.setPropertyValue("currentMode", "file-camera");
   assert.equal(q1.renderedPlaceholder, "both_mod_placeholder");
 });
+QUnit.test("QuestionFile allowImagesPreview and allowCameraAccess", function (assert) {
+  const prop1 = Serializer.getProperty("file", "allowImagesPreview");
+  assert.deepEqual(Serializer.getProperty("file", "showPreview").getDependedProperties(), [prop1.name]);
+  const q1 = new QuestionFileModel("q1");
+  q1.showPreview = true;
+  assert.equal(prop1.isVisible(undefined, q1), true);
+  q1.showPreview = false;
+  assert.equal(prop1.isVisible(undefined, q1), false);
+  const prop2 = Serializer.getProperty("file", "allowCameraAccess");
+  assert.equal(prop2.visible, false);
+});


### PR DESCRIPTION
Fixed #7192 - File Upload: The "Preview images" checkbox should be visible only if the "Show preview area" checkbox is selected
Fixed #7193 - File Upload: Hide "Allow camera access" from Property Grid