### PR TITLE
Fixed - HTML Question type unused properties are visible in creator

### DIFF
--- a/src/question_html.ts
+++ b/src/question_html.ts
@@ -55,8 +55,17 @@ export class QuestionHtmlModel extends QuestionNonValue {
 }
 Serializer.addClass(
   "html",
-  [{ name: "html:html", serializationProperty: "locHtml" }],
-  function() {
+  [
+    { name: "html:html", serializationProperty: "locHtml" },
+    { name: "hideNumber", visible: false },
+    { name: "state", visible: false },
+    { name: "titleLocation", visible: false },
+    { name: "descriptionLocation", visible: false },
+    { name: "errorLocation", visible: false },
+    { name: "indent", visible: false },
+    { name: "width", visible: false },
+  ],
+  function () {
     return new QuestionHtmlModel("");
   },
   "nonvalue"

--- a/tests/jsonobjecttests.ts
+++ b/tests/jsonobjecttests.ts
@@ -1,4 +1,4 @@
-﻿import {
+import {
   JsonObject,
   Serializer,
   JsonUnknownPropertyError,
@@ -2961,7 +2961,7 @@ QUnit.test("Add defaultFunc attribute support, Bug#5615", function (assert) {
   defaultValueForProp1 = 7;
   assert.equal(obj.prop1, 7, "The default value is 7 now");
 });
-QUnit.test("", function (assert) {
+QUnit.test("QuestionHtmlModel", function (assert) {
   let html = new QuestionHtmlModel("q1");
   assert.equal(html.renderAs, "default", "default is default");
   Serializer.addProperty("html", { name: "renderAs", default: "auto", choices: ["auto", "standard", "image"] });

--- a/tests/surveyquestiontests.ts
+++ b/tests/surveyquestiontests.ts
@@ -7615,3 +7615,10 @@ QUnit.test("Test", function (assert) {
   assert.deepEqual(survey.data, data2, "#2");
   assert.equal(counter, 0, "#2");
 });
+
+QUnit.test("QuestionHtmlModel hide some properties", function (assert) {
+  let html = new QuestionHtmlModel("q1");
+  ["hideNumber", "state", "titleLocation", "descriptionLocation", "errorLocation", "indent", "width"].forEach(property => {
+    assert.equal(Serializer.findProperty("html", property).visible, false, property + " should be hidden");
+  });
+});


### PR DESCRIPTION
https://github.com/surveyjs/survey-creator/issues/4814