### PR TITLE
I18n cleanup

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -1,6 +1,6 @@
 import { ILocalizableOwner, LocalizableString } from "../localizablestring";
 import { Base } from "../base";
-import { surveyLocalization } from "../surveyStrings";
+import { getString } from "../surveyStrings";
 import { property } from "../jsonobject";
 import { IListModel, ListModel } from "../list";
 import { IPopupOptionsBase, PopupModel } from "../popup";
@@ -426,7 +426,7 @@ export class Action extends BaseAction implements IAction, ILocalizableOwner {
   }
   private locTooltipChanged(): void {
     if (!this.locTooltipName) return;
-    this.tooltip = surveyLocalization.getString(this.locTooltipName, this.locTitle.locale);
+    this.tooltip = getString(this.locTooltipName, this.locTitle.locale);
   }
 
   //ILocalizableOwner

--- a/src/actions/adaptive-container.ts
+++ b/src/actions/adaptive-container.ts
@@ -2,7 +2,7 @@ import { ResponsivityManager } from "../utils/responsivity-manager";
 import { ListModel } from "../list";
 import { Action, actionModeType, createDropdownActionModelAdvanced, IAction } from "./action";
 import { ActionContainer } from "./container";
-import { surveyLocalization } from "../surveyStrings";
+import { getString } from "../surveyStrings";
 
 export class AdaptiveActionContainer<T extends Action = Action> extends ActionContainer<T> {
   public dotsItem: Action;
@@ -76,7 +76,7 @@ export class AdaptiveActionContainer<T extends Action = Action> extends ActionCo
       innerCss: "sv-dots__item",
       iconName: "icon-more",
       visible: false,
-      tooltip: surveyLocalization.getString("more"),
+      tooltip: getString("more"),
     }, {
       items: [],
       onSelectionChanged: (item: T) => {

--- a/src/base.ts
+++ b/src/base.ts
@@ -11,7 +11,7 @@ import { settings } from "./settings";
 import { ItemValue } from "./itemvalue";
 import { IElement, IFindElement, IProgressInfo, ISurvey } from "./base-interfaces";
 import { ExpressionRunner } from "./conditions";
-import { surveyLocalization } from "./surveyStrings";
+import { getString } from "./surveyStrings";
 import { ConsoleWarnings } from "./console-warnings";
 
 interface IExpressionRunnerInfo {
@@ -815,7 +815,7 @@ export class Base {
     return !!locOwner ? locOwner.getLocale(): "";
   }
   public getLocalizationString(strName: string): string {
-    return surveyLocalization.getString(strName, this.getLocale());
+    return getString(strName, this.getLocale());
   }
   public getLocalizationFormatString(strName: string, ...args: any[]): string {
     const str: any = this.getLocalizationString(strName);

--- a/src/entries/chunks/model.ts
+++ b/src/entries/chunks/model.ts
@@ -217,7 +217,7 @@ export { Cover, CoverCell } from "../../header";
 
 export { dxSurveyService } from "../../dxSurveyService";
 export { englishStrings } from "../../localization/english";
-export { surveyLocalization, surveyStrings } from "../../surveyStrings";
+export { surveyLocalization, surveyStrings, getString, registerLocale } from "../../surveyStrings";
 // export { cultureInfo } from "../../cultureInfo";
 export {
   QuestionCustomWidget,

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,4 +1,4 @@
-import { surveyLocalization } from "./surveyStrings";
+import { getString } from "./surveyStrings";
 import { SurveyError } from "./survey-error";
 import { ISurveyErrorOwner } from "./base-interfaces";
 
@@ -53,8 +53,7 @@ export class ExceedSizeError extends SurveyError {
     return "exceedsize";
   }
   public getDefaultText(): string {
-    return surveyLocalization
-      .getString("exceedMaxSize")
+    return getString("exceedMaxSize")
       ["format"](this.getTextSize());
   }
   private getTextSize() {
@@ -139,8 +138,7 @@ export class MinRowCountError extends SurveyError {
     return "minrowcounterror";
   }
   protected getDefaultText(): string {
-    return surveyLocalization
-      .getString("minRowCountError")
+    return getString("minRowCountError")
       ["format"](this.minRowCount);
   }
 }

--- a/src/jsonobject.ts
+++ b/src/jsonobject.ts
@@ -1,4 +1,4 @@
-import { surveyLocalization } from "./surveyStrings";
+import { getString } from "./surveyStrings";
 import { Base, ComputedUpdater } from "./base";
 import { Helpers, HashTable } from "./helpers";
 
@@ -42,7 +42,7 @@ function getLocStringValue(
   if (!!res) return res;
   if (typeof options.localizable === "object" && options.localizable.defaultStr) {
     const loc = !!target.getLocale ? target.getLocale() : "";
-    return surveyLocalization.getString(options.localizable.defaultStr, loc);
+    return getString(options.localizable.defaultStr, loc);
   }
   return "";
 }

--- a/src/localization/arabic.ts
+++ b/src/localization/arabic.ts
@@ -1,4 +1,4 @@
-import { surveyLocalization } from "survey-core";
+import { registerLocale } from "survey-core";
 
 export var arabicSurveyStrings = {
   pagePrevText: "السابق",
@@ -97,8 +97,7 @@ export var arabicSurveyStrings = {
   selectToRankEmptyUnrankedAreaText: "قم بسحب وإسقاط الخيارات هنا لترتيبها"
 };
 
-surveyLocalization.locales["ar"] = arabicSurveyStrings;
-surveyLocalization.localeNames["ar"] = "العربية";
+registerLocale("ar", "العربية", arabicSurveyStrings);
 
 // The following strings have been translated by a machine translation service
 // Remove those strings that you have corrected manually

--- a/src/localization/basque.ts
+++ b/src/localization/basque.ts
@@ -1,4 +1,4 @@
-import { surveyLocalization } from "survey-core";
+import { registerLocale } from "survey-core";
 
 export var basqueSurveyStrings = {
   pagePrevText: "Aurrekoa",
@@ -97,8 +97,7 @@ export var basqueSurveyStrings = {
   selectToRankEmptyUnrankedAreaText: "Arrastaka eta askatzen ditu hemen sailkatzeko"
 };
 
-surveyLocalization.locales["eu"] = basqueSurveyStrings;
-surveyLocalization.localeNames["eu"] = "Euskara";
+registerLocale("eu", "Euskara", basqueSurveyStrings);
 
 // The following strings have been translated by a machine translation service
 // Remove those strings that you have corrected manually

--- a/src/question_baseselect.ts
+++ b/src/question_baseselect.ts
@@ -4,7 +4,7 @@ import { ISurveyImpl, ISurvey, ISurveyData, IPlainDataOptions, IValueItemCustomP
 import { SurveyModel } from "./survey";
 import { IQuestionPlainData, Question } from "./question";
 import { ItemValue } from "./itemvalue";
-import { surveyLocalization } from "./surveyStrings";
+import { getString } from "./surveyStrings";
 import { OtherEmptyError } from "./error";
 import { ChoicesRestful } from "./choicesRestful";
 import { LocalizableString } from "./localizablestring";
@@ -1847,7 +1847,7 @@ Serializer.addClass(
     {
       name: "choices:itemvalue[]", uniqueProperty: "value",
       baseValue: function () {
-        return surveyLocalization.getString("choices_Item");
+        return getString("choices_Item");
       },
       dependsOn: "choicesFromQuestion",
       visibleIf: (obj: any) => {

--- a/src/question_boolean.ts
+++ b/src/question_boolean.ts
@@ -2,7 +2,6 @@ import { QuestionFactory } from "./questionfactory";
 import { property, Serializer } from "./jsonobject";
 import { Question } from "./question";
 import { LocalizableString } from "./localizablestring";
-import { surveyLocalization } from "./surveyStrings";
 import { CssClassBuilder } from "./utils/cssClassBuilder";
 import { preventDefaults } from "./utils/utils";
 import { ActionContainer } from "./actions/container";

--- a/src/question_checkbox.ts
+++ b/src/question_checkbox.ts
@@ -6,7 +6,6 @@ import {
 } from "./question_baseselect";
 import { Helpers } from "./helpers";
 import { ItemValue } from "./itemvalue";
-import { surveyLocalization } from "./surveyStrings";
 import { LocalizableString } from "./localizablestring";
 import { CssClassBuilder } from "./utils/cssClassBuilder";
 import { IQuestion } from "./base-interfaces";

--- a/src/question_matrix.ts
+++ b/src/question_matrix.ts
@@ -4,7 +4,7 @@ import { QuestionMatrixBaseModel } from "./martixBase";
 import { JsonObject, Serializer } from "./jsonobject";
 import { Base } from "./base";
 import { SurveyError } from "./survey-error";
-import { surveyLocalization } from "./surveyStrings";
+import { getString } from "./surveyStrings";
 import { RequiredInAllRowsError } from "./error";
 import { QuestionFactory } from "./questionfactory";
 import { LocalizableString, ILocalizableOwner } from "./localizablestring";
@@ -628,13 +628,13 @@ Serializer.addClass(
     {
       name: "columns:itemvalue[]", uniqueProperty: "value",
       baseValue: function() {
-        return surveyLocalization.getString("matrix_column");
+        return getString("matrix_column");
       },
     },
     {
       name: "rows:itemvalue[]", uniqueProperty: "value",
       baseValue: function() {
-        return surveyLocalization.getString("matrix_row");
+        return getString("matrix_row");
       },
     },
     { name: "cells:cells", serializationProperty: "cells" },

--- a/src/question_matrixdropdownrendered.ts
+++ b/src/question_matrixdropdownrendered.ts
@@ -2,7 +2,6 @@ import { property, propertyArray } from "./jsonobject";
 import { Question } from "./question";
 import { Base, ComputedUpdater } from "./base";
 import { ItemValue } from "./itemvalue";
-import { surveyLocalization } from "./surveyStrings";
 import { LocalizableString } from "./localizablestring";
 import { PanelModel } from "./panel";
 import { Action, IAction } from "./actions/action";

--- a/src/question_matrixdynamic.ts
+++ b/src/question_matrixdynamic.ts
@@ -6,7 +6,6 @@ import {
   MatrixDropdownRowModelBase,
   IMatrixDropdownData
 } from "./question_matrixdropdownbase";
-import { surveyLocalization } from "./surveyStrings";
 import { LocalizableString } from "./localizablestring";
 import { SurveyError } from "./survey-error";
 import { MinRowCountError } from "./error";

--- a/src/question_radiogroup.ts
+++ b/src/question_radiogroup.ts
@@ -1,7 +1,6 @@
 import { Serializer } from "./jsonobject";
 import { QuestionFactory } from "./questionfactory";
 import { QuestionCheckboxBase } from "./question_baseselect";
-import { surveyLocalization } from "./surveyStrings";
 import { ItemValue } from "./itemvalue";
 import { Action } from "./actions/action";
 import { ComputedUpdater } from "./base";

--- a/src/question_rating.ts
+++ b/src/question_rating.ts
@@ -4,7 +4,7 @@ import { property, propertyArray, Serializer } from "./jsonobject";
 import { QuestionFactory } from "./questionfactory";
 import { LocalizableString } from "./localizablestring";
 import { settings } from "./settings";
-import { surveyLocalization } from "./surveyStrings";
+import { getString } from "./surveyStrings";
 import { CssClassBuilder } from "./utils/cssClassBuilder";
 import { Base } from "./base";
 import { mergeValues } from "./utils/utils";
@@ -157,7 +157,7 @@ export class QuestionRatingModel extends Question {
             this.rateValues.splice(this.rateCount, this.rateValues.length - this.rateCount);
           } else {
             for (let i = this.rateValues.length; i < this.rateCount; i++) {
-              this.rateValues.push(new ItemValue(surveyLocalization.getString("choices_Item") + (i + 1)));
+              this.rateValues.push(new ItemValue(getString("choices_Item") + (i + 1)));
             }
           }
         }
@@ -893,7 +893,7 @@ Serializer.addClass(
     {
       name: "rateValues:itemvalue[]",
       baseValue: function () {
-        return surveyLocalization.getString("choices_Item");
+        return getString("choices_Item");
       },
       category: "rateValues",
       visibleIf: function (obj: any) {

--- a/src/question_signaturepad.ts
+++ b/src/question_signaturepad.ts
@@ -1,5 +1,4 @@
 import { property, Serializer } from "./jsonobject";
-import { surveyLocalization } from "./surveyStrings";
 import { QuestionFactory } from "./questionfactory";
 import { Question } from "./question";
 import SignaturePad from "signature_pad";

--- a/src/questionfactory.ts
+++ b/src/questionfactory.ts
@@ -1,7 +1,7 @@
 import { HashTable } from "./helpers";
 import { Question } from "./question";
 import { IElement } from "./base-interfaces";
-import { surveyLocalization } from "./surveyStrings";
+import { getString } from "./surveyStrings";
 import { Serializer } from "./jsonobject";
 import { ComponentCollection } from "./question_custom";
 
@@ -9,21 +9,21 @@ export class QuestionFactory {
   public static Instance: QuestionFactory = new QuestionFactory();
   public static get DefaultChoices(): string[] {
     return [
-      surveyLocalization.getString("choices_Item") + "1",
-      surveyLocalization.getString("choices_Item") + "2",
-      surveyLocalization.getString("choices_Item") + "3",
+      getString("choices_Item") + "1",
+      getString("choices_Item") + "2",
+      getString("choices_Item") + "3",
     ];
   }
   public static get DefaultColums(): string[] {
-    var colName = surveyLocalization.getString("matrix_column") + " ";
+    var colName = getString("matrix_column") + " ";
     return [colName + "1", colName + "2", colName + "3"];
   }
   public static get DefaultRows(): string[] {
-    var rowName = surveyLocalization.getString("matrix_row") + " ";
+    var rowName = getString("matrix_row") + " ";
     return [rowName + "1", rowName + "2"];
   }
   public static get DefaultMutlipleTextItems(): string[] {
-    var itemName = surveyLocalization.getString("multipletext_itemname");
+    var itemName = getString("multipletext_itemname");
     return [itemName + "1", itemName + "2"];
   }
   public registerQuestion(questionType: string, questionCreator: (name: string) => Question): void {

--- a/src/stylesmanager.ts
+++ b/src/stylesmanager.ts
@@ -256,7 +256,7 @@ export class StylesManager {
     "darkrose": darkroseThemeColors,
     "stone": stoneThemeColors,
     "winter": winterThemeColors,
-    "winterstone": winterstoneThemeColors,
+    "winterstoneregisterFunctionOnPropertyValueChangedregisterFunctionOnPropertyValueChangedregisterFunctionOnPropertyValueChangedregisterFunctionOnPropertyValueChangedregisterFunctionOnPropertyValueChangedregisterFunctionOnPropertyValueChangedregisterFunctionOnPropertyValueChanged": winterstoneThemeColors,
   };
   public static ThemeCss: { [key: string]: { [key: string]: string } } = { };
   public static ThemeSelector: { [key: string]: string } = {

--- a/src/survey-error.ts
+++ b/src/survey-error.ts
@@ -1,6 +1,6 @@
 import { ISurveyErrorOwner } from "./base-interfaces";
 import { LocalizableString } from "./localizablestring";
-import { surveyLocalization } from "./surveyStrings";
+import { getString } from "./surveyStrings";
 
 export class SurveyError {
   private locTextValue: LocalizableString;
@@ -41,7 +41,7 @@ export class SurveyError {
     return !!this.errorOwner ? this.errorOwner.getLocale(): "";
   }
   protected getLocalizationString(locStrName: string): string {
-    return surveyLocalization.getString(locStrName, this.getLocale());
+    return getString(locStrName, this.getLocale());
   }
   public onUpdateErrorTextCallback: (error: SurveyError) => void = undefined;
   public updateText(): void {

--- a/src/surveyStrings.ts
+++ b/src/surveyStrings.ts
@@ -1,10 +1,13 @@
 import { englishStrings } from "./localization/english";
 
+export function getString(strName: string, locale: string = null) {
+  return surveyLocalization.getString(strName, locale);
+}
 export var surveyLocalization = {
   currentLocaleValue: "",
   defaultLocaleValue: "en",
-  locales: <{ [index: string]: any }>{},
-  localeNames: <{ [index: string]: any }>{},
+  locales: <Record<string, Record<string, string>>>{},
+  localeNames: <Record<string, string>>{},
   supportedLocales: <Array<any>>[],
   get currentLocale() {
     return this.currentLocaleValue === this.defaultLocaleValue ? "" : this.currentLocaleValue;

--- a/src/surveyStrings.ts
+++ b/src/surveyStrings.ts
@@ -1,5 +1,10 @@
 import { englishStrings } from "./localization/english";
 
+export function registerLocale(code: string, name: string, localeStrings: Record<string, string>) {
+  surveyLocalization.locales[code] = localeStrings;
+  surveyLocalization.localeNames[code] = name;
+}
+
 export function getString(strName: string, locale: string = null) {
   return surveyLocalization.getString(strName, locale);
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,7 +1,7 @@
 import { LocalizableString } from "../localizablestring";
 import { settings, ISurveyEnvironment } from "./../settings";
 import { IDialogOptions } from "../popup";
-import { surveyLocalization } from "../surveyStrings";
+import { getString } from "../surveyStrings";
 import { PopupBaseViewModel } from "../popup-view-model";
 
 function compareVersions(a: any, b: any) {
@@ -430,9 +430,9 @@ export function showConfirmDialog(message: string, callback: (res: boolean) => v
   const toolbar = popupViewModel.footerToolbar;
   const applyBtn = toolbar.getActionById("apply");
   const cancelBtn = toolbar.getActionById("cancel");
-  cancelBtn.title = surveyLocalization.getString("cancel");
+  cancelBtn.title = getString("cancel");
   cancelBtn.innerCss = "sv-popup__body-footer-item sv-popup__button sd-btn sd-btn--small";
-  applyBtn.title = applyTitle || surveyLocalization.getString("ok");
+  applyBtn.title = applyTitle || getString("ok");
   applyBtn.innerCss = "sv-popup__body-footer-item sv-popup__button sv-popup__button--danger sd-btn sd-btn--small sd-btn--danger";
   popupViewModel.width = "452px";
   return true;

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -2,7 +2,6 @@ import { Base } from "./base";
 import { ISurveyErrorOwner, ISurvey } from "./base-interfaces";
 import { SurveyError } from "./survey-error";
 import { CustomError, RequreNumericError } from "./error";
-import { surveyLocalization } from "./surveyStrings";
 import { ILocalizableOwner, LocalizableString } from "./localizablestring";
 import { Serializer } from "./jsonobject";
 import { ConditionRunner } from "./conditions";


### PR DESCRIPTION
The idea of this PR is to clean up the i18n code a bit:
1. Instead of importing the full mutable object everywhere we just import a reader `getString()`
2. For new translations we export a registration function instead of writing to the object in multiple places.


The goal of this is to create some abstraction instead of having a global, largely untyped, object being changed everywhere in the code.
I'd like feedback on point 2 before I apply it to all translations.