### PR TITLE
Work for https://github.com/surveyjs/survey-creator/issues/4889 - The 'Cannot read properties of undefined (reading 'value')' exception is thrown when using the Ctrl+Z to reset a calculated field name to the initial value

### DIFF
--- a/src/question_comment.ts
+++ b/src/question_comment.ts
@@ -97,7 +97,7 @@ export class QuestionCommentModel extends QuestionTextBase {
     this.updateRemainingCharacterCounter(event.target.value);
   }
   public onKeyDown(event: any): void {
-    this.checkForUndo(event);
+    this.onKeyDownPreprocess && this.onKeyDownPreprocess(event);
     if (!this.acceptCarriageReturn && (event.key === "Enter" || event.keyCode === 13)) {
       event.preventDefault();
       event.stopPropagation();

--- a/src/question_text.ts
+++ b/src/question_text.ts
@@ -441,7 +441,7 @@ export class QuestionTextModel extends QuestionTextBase {
     this.updateRemainingCharacterCounter(event.target.value);
   };
   public onKeyDown = (event: any) => {
-    this.checkForUndo(event);
+    this.onKeyDownPreprocess && this.onKeyDownPreprocess(event);
     if (this.isInputTextUpdate) {
       this._isWaitingForEnter = event.keyCode === 229;
     }

--- a/src/question_textbase.ts
+++ b/src/question_textbase.ts
@@ -125,14 +125,6 @@ export class QuestionTextBase extends Question {
     return val;
   }
   protected getValueSeparator(): string { return ", "; }
-  public disableNativeUndoRedo = false;
-  protected checkForUndo(event: KeyboardEvent) {
-    if (this.disableNativeUndoRedo && this.isInputTextUpdate && (event.ctrlKey || event.metaKey)) {
-      if ([89, 90].indexOf(event.keyCode) !== -1) {
-        event.preventDefault();
-      }
-    }
-  }
   protected getControlCssClassBuilder(): CssClassBuilder {
     return new CssClassBuilder()
       .append(this.cssClasses.root)
@@ -148,6 +140,8 @@ export class QuestionTextBase extends Question {
     return true;
   }
   // EO a11y
+
+  public onKeyDownPreprocess: (event: any) => void;
 }
 Serializer.addClass(
   "textbase", [],

--- a/tests/question_texttests.ts
+++ b/tests/question_texttests.ts
@@ -305,69 +305,7 @@ QUnit.test("Test event handlers with on typing text update mode", function(asser
   fakeInput.remove();
 });
 
-QUnit.test("Test event prevent default on typing text update mode", function(assert) {
-  const testInput = document.createElement("input");
-  const fakeInput = document.createElement("input");
-  document.body.appendChild(testInput);
-  document.body.appendChild(fakeInput);
-  let survey = new SurveyModel({
-    elements: [
-      { type: "text", name: "q1" },
-      { type: "comment", name: "q2" },
-    ]
-  });
-  let q1 = <QuestionTextModel>survey.getQuestionByName("q1");
-  let q2 = <QuestionTextModel>survey.getQuestionByName("q2");
-  q1.disableNativeUndoRedo = true;
-  q2.disableNativeUndoRedo = true;
-  const eventCtrlZ = {
-    target: testInput,
-    keyCode: 90,
-    ctrlKey: true,
-    preventDefault: ()=>{ defaultPrevented = true; }
-  };
-  const eventCtrlY = {
-    target: testInput,
-    keyCode: 89,
-    ctrlKey: true,
-    preventDefault: ()=>{ defaultPrevented = true; }
-  };
-
-  let defaultPrevented = false;
-  q1.onKeyDown(eventCtrlZ);
-  assert.notOk(defaultPrevented, "text ctrl+Z");
-
-  q1.onKeyDown(eventCtrlY);
-  assert.notOk(defaultPrevented, "text ctrl+Y");
-
-  q2.onKeyDown(eventCtrlZ);
-  assert.notOk(defaultPrevented, "comment ctrl+Z");
-
-  q2.onKeyDown(eventCtrlY);
-  assert.notOk(defaultPrevented, "comment ctrl+Y");
-
-  survey.textUpdateMode = "onTyping";
-
-  q1.onKeyDown(eventCtrlZ);
-  assert.ok(defaultPrevented, "text onTyping ctrl+Z");
-
-  defaultPrevented = false;
-  q1.onKeyDown(eventCtrlY);
-  assert.ok(defaultPrevented, "text onTyping ctrl+Y");
-
-  survey.textUpdateMode = "onTyping";
-  q2.onKeyDown(eventCtrlZ);
-  assert.ok(defaultPrevented, "comment onTyping ctrl+Z");
-
-  defaultPrevented = false;
-  q2.onKeyDown(eventCtrlY);
-  assert.ok(defaultPrevented, "comment onTyping ctrl+Y");
-
-  testInput.remove();
-  fakeInput.remove();
-});
-
-QUnit.test("Test event handlers do not change question'value if newValue is same", function(assert) {
+QUnit.test("Test event handlers do not change question'value if newValue is same", function (assert) {
   let log = "";
   const testInput = document.createElement("input");
   class QuestionTextTest extends QuestionTextModel {


### PR DESCRIPTION
Base work for https://github.com/surveyjs/survey-creator/pull/4902
- The 'Cannot read properties of undefined (reading 'value')' exception is thrown when using the Ctrl+Z to reset a calculated field name to the initial value