### PR TITLE
Link Demo for defaultValueExpression

### DIFF
--- a/src/question.ts
+++ b/src/question.ts
@@ -1656,8 +1656,6 @@ export class Question extends SurveyElement<Question>
   /**
    * An expression used to calculate the [defaultValue](https://surveyjs.io/form-library/documentation/question#defaultValue).
    *
-   * [View Demo](https://surveyjs.io/form-library/examples/specify-default-question-value-dynamically (linkStyle)
-   *
    * This expression applies until the question [value](https://surveyjs.io/form-library/documentation/question#value) is specified by an end user or programmatically.
    *
    * An expression can reference other questions as follows:
@@ -1667,6 +1665,8 @@ export class Question extends SurveyElement<Question>
    * - `{row.other_question_name}` (to access questions inside the same dynamic matrix or multi-column dropdown)
    *
    * An expression can also include built-in and custom functions for advanced calculations. For example, if the `defaultValue` should be today's date, set the `defaultValueExpression` to `"today()"`, and the corresponding built-in function will be executed each time the survey is loaded. Refer to the following help topic for more information: [Built-In Functions](https://surveyjs.io/form-library/documentation/design-survey-conditional-logic#built-in-functions).
+   *
+   * [View Demo](https://surveyjs.io/form-library/examples/specify-default-question-value-dynamically (linkStyle)
    * @see defaultValue
    * @see setValueExpression
    */

--- a/src/question.ts
+++ b/src/question.ts
@@ -1656,6 +1656,8 @@ export class Question extends SurveyElement<Question>
   /**
    * An expression used to calculate the [defaultValue](https://surveyjs.io/form-library/documentation/question#defaultValue).
    *
+   * [View Demo](https://surveyjs.io/form-library/examples/specify-default-question-value-dynamically (linkStyle)
+   *
    * This expression applies until the question [value](https://surveyjs.io/form-library/documentation/question#value) is specified by an end user or programmatically.
    *
    * An expression can reference other questions as follows:


### PR DESCRIPTION
Update the [question.defaultValueExpression](https://surveyjs.io/form-library/documentation/api-reference/question#defaultValueExpression) property and link the [Dynamic Default Question Values](https://surveyjs.io/form-library/examples/specify-default-question-value-dynamically) demo.