### PR TITLE
The 'Cannot read properties of undefined (reading 'getContext')' exception is thrown when a form is submitted with an invisible Signature Pad

### DIFF
--- a/src/question_signaturepad.ts
+++ b/src/question_signaturepad.ts
@@ -118,6 +118,7 @@ export class QuestionSignaturePadModel extends QuestionFileModelBase {
     };
   }
   private refreshCanvas() {
+    if(!this.canvas) return;
     if (!this.value) {
       this.canvas.getContext("2d").clearRect(0, 0, this.canvas.width * this.scale, this.canvas.height * this.scale);
       this.signaturePad.clear();

--- a/tests/question_signaturepadtests.ts
+++ b/tests/question_signaturepadtests.ts
@@ -489,3 +489,24 @@ QUnit.test("Question Signature upload files - and complete", function (assert) {
 
 });
 
+QUnit.test("Question Signature pad invisible - on complete", function (assert) {
+  var json = {
+    questions: [
+      {
+        type: "text",
+        name: "text"
+      },
+      {
+        type: "signaturepad",
+        name: "signature",
+        visibleIf: "{text} = 'cba'"
+      },
+    ],
+  };
+
+  var survey = new SurveyModel(json);
+  survey.getQuestionByName("text").value = "abc";
+  survey.doComplete();
+  assert.deepEqual(survey.data, { text: "abc" });
+});
+


### PR DESCRIPTION
Fixes #7478