### PR TITLE
Fixed an XSS vulnerability when setting SVG icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@types/ace": "0.0.32",
     "@types/angular": "^1.6.2",
     "@types/babel__traverse": "7.18.2",
+    "@types/dompurify": "^3.0.5",
     "@types/jest": "23.3.3",
     "@types/jquery": "^2.0.39",
     "@types/lodash": "4.14.186",
@@ -209,6 +210,7 @@
     }
   },
   "dependencies": {
+    "dompurify": "^3.0.6",
     "signature_pad": "^4.1.5",
     "vite": "^3.1.8"
   }

--- a/src/svgbundle.ts
+++ b/src/svgbundle.ts
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify'
+
 class SvgIconData {
   [key: string]: string
 }
@@ -32,17 +34,17 @@ export class SvgIconRegistry {
     const startStr = "<svg ";
     const endStr = "</svg>";
     iconSvg = iconSvg.trim();
-    const str = iconSvg.toLowerCase();
+    const str = DOMPurify.sanitize(iconSvg.toLowerCase());
 
-    if(str.substring(0, startStr.length) === startStr &&
-       str.substring(str.length - endStr.length, str.length) === endStr) {
+    if (str.substring(0, startStr.length) === startStr &&
+      str.substring(str.length - endStr.length, str.length) === endStr) {
       this.registerIconFromSymbol(iconId, "<symbol " +
-              "id=\"" + iconPrefix + iconId + "\" " +
-              iconSvg.substring(startStr.length, str.length - endStr.length) +
-              "</symbol>");
+        "id=\"" + iconPrefix + iconId + "\" " +
+        iconSvg.substring(startStr.length, str.length - endStr.length) +
+        "</symbol>");
       return true;
     }
-    else{
+    else {
       return false;
     }
 

--- a/src/svgbundle.ts
+++ b/src/svgbundle.ts
@@ -1,4 +1,4 @@
-import DOMPurify from 'dompurify'
+import DOMPurify from "dompurify";
 
 class SvgIconData {
   [key: string]: string


### PR DESCRIPTION
I've discovered a stored XSS vulnerability in `src/svgbundle.ts`:

__Vulnerability Details__:
Severity: [High/Critical – Stored XSS can have a significant impact. Adjust based on your assessment]
The function `SvgIconRegistry.registerIconFromSvg()` is used to register and replace icons within the SVG registry, such as the default checkbox icon. However, the user of the library might inject a malicious SVG into the site, which cause an attacker to be able to execute arbitrary script under the domain (XSS)

__Steps to Reproduce__:
Let's say we have an SVG in this form:
```xml
<svg >
  <a href='javascript:alert(window.origin)'>
    <text>hello</text>
  </a>
</svg>
```
Such SVG could be registered under the registry with this script:
```js
import { SvgRegistry } from 'survey-core'
SvgRegistry.registerIconFromSvg("v2check", maliciousSvg)
```
When we display a checkbox in the survey, after the user clicks them, an alert would show up. suggesting that the script has been successfully executed.

Here's a screenshot example if we display the checkbox using the example in the Surveyjs documentation:
![image](https://github.com/surveyjs/survey-library/assets/27280516/92da52d8-b1ce-4bcf-90c7-9235b8608ac0)

__Suggested Fix__:
Before an SVG got registered into the registry, it is best to sanitize them first, using a library such as `DOMPurify` to prevent script execution. I have implemented a simple patch to fix the vulnerability using this method.