### PR TITLE
Fix: Prevent clear of other questions when question name equals other value name

### DIFF
--- a/src/question.ts
+++ b/src/question.ts
@@ -1549,8 +1549,7 @@ export class Question extends SurveyElement<Question>
     if (this.isVisibleInSurvey) return false;
     if (!!this.page && this.page.isStartPage) return false;
     if (!this.survey) return true;
-    const valueName = this.valueName ?? this.name;
-    return !this.survey.hasVisibleQuestionByValueName(valueName);
+    return !this.survey.hasVisibleQuestionByValueName(this.getValueName());
   }
   /**
    * Returns `true` if a parent element (page or panel) is visible.

--- a/src/question.ts
+++ b/src/question.ts
@@ -1548,8 +1548,9 @@ export class Question extends SurveyElement<Question>
     if (reason === "onHiddenContainer" && !this.isParentVisible) return true;
     if (this.isVisibleInSurvey) return false;
     if (!!this.page && this.page.isStartPage) return false;
-    if (!this.survey || !this.valueName) return true;
-    return !this.survey.hasVisibleQuestionByValueName(this.valueName);
+    if (!this.survey) return true;
+    const valueName = this.valueName ?? this.name;
+    return !this.survey.hasVisibleQuestionByValueName(valueName);
   }
   /**
    * Returns `true` if a parent element (page or panel) is visible.

--- a/tests/surveytests.ts
+++ b/tests/surveytests.ts
@@ -3537,6 +3537,20 @@ QUnit.test(
     assert.deepEqual(survey.data, {}, "The value should be cleaned");
   }
 );
+QUnit.test(
+  "clearInvisibleValues is onComplete (default value), visible and invisible questions with the same name and valueName",
+  function (assert) {
+    const survey = new SurveyModel();
+    const page = survey.addNewPage("page");
+    const q1 = <QuestionTextModel>page.addNewQuestion("text", "q1");
+    const q2 = <QuestionTextModel>page.addNewQuestion("text", "q2");
+    q2.valueName = "q1";
+    q2.value = 1;
+    q1.visible = false;
+    survey.doComplete();
+    assert.deepEqual(survey.data, { q1: 1 }, "The value should be kept");
+  }
+);
 QUnit.test("clearInvisibleValues - comments and other values, #309", function (
   assert
 ) {


### PR DESCRIPTION
By default, the values of all invisible questions are cleared on complete to exclude the data from the result. As multiple questions may have the same value name, it is checked wherever there is another question with the same value name is visible before clearing the value. 
However, this check does not take into account, that the question name is the default value name when no value name is provided. This causes all questions with the same value name as the question name to be cleared.

This PR suggests using `getValueName` instead, which falls back to the question name if no value name is defined.

<details>
  <summary>Example Survey</summary>
  
```json
{
 "pages": [
  {
   "name": "page1",
   "elements": [
    {
     "type": "boolean",
     "name": "toggle",
     "title": "Toggle",
     "labelTrue": "Bug",
     "labelFalse": "It works"
    },
    {
     "type": "text",
     "name": "username",
     "visibleIf": "{toggle} = false",
     "title": "Username",
     "maxLength": 25
    },
    {
     "type": "text",
     "name": "alternative_username",
     "visibleIf": "{toggle} = true",
     "title": "Alternative Username",
     "valueName": "username"
    }
   ]
  }
 ],
 "showQuestionNumbers": "off"
}
```
</details>