### PR TITLE
survey.mergeData API - Update a link to the doc topic

### DIFF
--- a/src/survey.ts
+++ b/src/survey.ts
@@ -2755,7 +2755,7 @@ export class SurveyModel extends SurveyElementCore
   /**
    * Merges a specified data object with the object from the [`data`](https://surveyjs.io/form-library/documentation/api-reference/survey-data-model#data) property.
    *
-   * Refer to the following help topic for more information: [Merge Question Values](https://surveyjs.io/form-library/documentation/design-survey/merge-question-values).
+   * Refer to the following help topic for more information: [Populate Form Fields | Multiple Question Values](https://surveyjs.io/form-library/documentation/design-survey/pre-populate-form-fields#multiple-question-values).
    *
    * @param data A data object to merge. It should have the following structure: `{ questionName: questionValue, ... }`
    * @see setValue


### PR DESCRIPTION
The [survey.mergeData](https://surveyjs.io/form-library/documentation/api-reference/survey-data-model#mergeData) description contains a link to a topic which covers another usage scenario: https://surveyjs.io/form-library/documentation/design-survey/merge-question-values.

It should contain a link to the following topic: https://surveyjs.io/form-library/documentation/design-survey/pre-populate-form-fields#multiple-question-values.