### PR TITLE
fix: 🐛 resolved globalThis is undefinded in react-native-window

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,7 +11,7 @@ export type ISurveyEnvironment = {
   svgMountContainer: HTMLElement | string,
   stylesSheetsMountContainer: HTMLElement,
 }
-const document = globalThis.document;
+const document = typeof globalThis !== "undefined" ? globalThis.document : (this as any).document;
 const defaultEnvironment: ISurveyEnvironment = <ISurveyEnvironment>(!!document ? {
   root: document,
 


### PR DESCRIPTION
globleThis is showing `undefinded` in react-native-windows Edge browser, this simple solution is to check the type if is `undefinded`, if so, use `self` instead, which is working in Edge

My Windows environment is:
react-native-windows: 0.69.6
survey-core: 1.9.121
survey-react-ui: 1.9.121,
Microsoft Edge DevTools debugger - Edge browser

## Screenshot
![Microsoft Edge DevTools Preview 1_4_2024 4_15_12 PM](https://github.com/surveyjs/survey-library/assets/61330285/4183e012-bc35-48c2-b9c3-9a29221ec34b)

