### PR TITLE
A question description doesn't appear on a design surface when the 'l…

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -390,8 +390,7 @@ export class Base {
     if (!!this.loadingOwner && this.loadingOwner.isLoadingFromJson) return true;
     return this.isLoadingFromJsonValue;
   }
-
-  startLoadingFromJson(json?: any) {
+  startLoadingFromJson(json?: any): void {
     this.isLoadingFromJsonValue = true;
     this.jsonObj = json;
   }

--- a/src/survey.ts
+++ b/src/survey.ts
@@ -6048,13 +6048,19 @@ export class SurveyModel extends SurveyElementCore
     if (!json) return;
     this.questionHashesClear();
     this.jsonErrors = null;
-    var jsonConverter = new JsonObject();
+    const jsonConverter = new JsonObject();
     jsonConverter.toObject(json, this, options);
     if (jsonConverter.errors.length > 0) {
       this.jsonErrors = jsonConverter.errors;
     }
     this.onStateAndCurrentPageChanged();
     this.updateState();
+  }
+  startLoadingFromJson(json?: any): void {
+    super.startLoadingFromJson(json);
+    if(json && json.locale) {
+      this.locale = json.locale;
+    }
   }
   public setJsonObject(jsonObj: any): void {
     this.fromJSON(jsonObj);

--- a/tests/surveytests.ts
+++ b/tests/surveytests.ts
@@ -19174,3 +19174,30 @@ QUnit.test("survey.runExpressions(), #7694", function (assert) {
 
   FunctionFactory.Instance.unregister("func1");
 });
+QUnit.test("survey.locale, default locale is not en and design-time, #7765", function (assert) {
+  const defautlLocale = surveyLocalization.defaultLocale;
+  surveyLocalization.defaultLocale = "fr";
+  const json = {
+    elements: [
+      {
+        type: "text",
+        name: "q1",
+        title: {
+          de: "German title",
+          en: "English question title",
+        },
+        description: {
+          de: "German description",
+          en: "English element description",
+        }
+      }
+    ],
+    locale: "de",
+  };
+  const survey = new SurveyModel();
+  survey.setDesignMode(true);
+  survey.fromJSON(json);
+  const q1 = survey.getQuestionByName("q1");
+  assert.equal(q1.hasDescription, true, "Description loaded correctly");
+  surveyLocalization.defaultLocale = defautlLocale;
+});


### PR DESCRIPTION
…ocale' key is defined at the end of a survey JSON fix #7765