### PR TITLE
Update hebrew.ts

### DIFF
--- a/src/localization/hebrew.ts
+++ b/src/localization/hebrew.ts
@@ -78,7 +78,7 @@ export var hebrewSurveyStrings = {
   timerLimitAll: "הוצאת {0} מתוך {1} בדף זה ו- {2} מתוך {3} בסך הכל.",
   timerLimitPage: "הוצאת {0} מתוך {1} בדף זה.",
   timerLimitSurvey: "הוצאת סכום כולל של {0} מתוך {1}.",
-  clearCaption: "ברור",
+  clearCaption: "לנקות",
   signaturePlaceHolder: "חתום כאן",
   chooseFileCaption: "בחר קובץ",
   takePhotoCaption: "צלם תמונה",


### PR DESCRIPTION
Word used for "clearCaption" translation to hebrew is wrong in this context. 

Used translation is right in context of, for example, "clear sky", or "it's clear", but wrong in context of "to clear something'