### PR TITLE
Issue/8037-The-Min-mask-setting-prevents-a-value-from-being-removed-when-it-is-below-the-specified-minimum-value

### DIFF
--- a/src/mask/mask_numeric.ts
+++ b/src/mask/mask_numeric.ts
@@ -153,7 +153,7 @@ export class InputMaskNumeric extends InputMaskBase {
     return value;
   }
 
-  public validateNumber(number: INumericalComposition): boolean {
+  public validateNumber(number: INumericalComposition, matchWholeMask: boolean): boolean {
     const min = this.min || Number.MIN_SAFE_INTEGER;
     const max = this.max || Number.MAX_SAFE_INTEGER;
 
@@ -162,7 +162,11 @@ export class InputMaskNumeric extends InputMaskBase {
       if(Number.isNaN(value)) {
         return true;
       }
-      return value >= min && value <= max;
+      if (!matchWholeMask) {
+        return value >= 0 && value <= max || value < 0 && value >= min;
+      } else {
+        return value >= min && value <= max;
+      }
     }
     return true;
   }
@@ -179,7 +183,7 @@ export class InputMaskNumeric extends InputMaskBase {
       const currentChar = input[inputIndex];
       switch(currentChar) {
         case "-": {
-          if(this.allowNegativeValues) {
+          if (this.allowNegativeValues && (this.min === undefined || this.min < 0)) {
             minusCharCount++;
           }
           break;
@@ -217,6 +221,9 @@ export class InputMaskNumeric extends InputMaskBase {
   public getNumberMaskedValue(src: string | number, matchWholeMask: boolean = false): string {
     const input = (src === undefined || src === null) ? "" : src;
     const parsedNumber = this.parseNumber(input);
+    if (!this.validateNumber(parsedNumber, matchWholeMask)) {
+      return null;
+    }
     const displayText = this.displayNumber(parsedNumber, true, matchWholeMask);
     return displayText;
   }
@@ -239,7 +246,7 @@ export class InputMaskNumeric extends InputMaskBase {
     const src = leftPart + rightPart;
     const parsedNumber = this.parseNumber(src);
 
-    if(!this.validateNumber(parsedNumber)) {
+    if (!this.validateNumber(parsedNumber, false)) {
       return result;
     }
 

--- a/tests/mask/mask_number_tests.ts
+++ b/tests/mask/mask_number_tests.ts
@@ -36,18 +36,18 @@ QUnit.test("parseNumber", assert => {
   assert.equal(maskInstance.parseNumber("123.").fractionalPart, 0);
 });
 
-QUnit.test("validationNumber", function(assert) {
+QUnit.test("validationNumber: matchWholeMask is true", function(assert) {
   let maskInstance = new InputMaskNumeric();
-  assert.equal(maskInstance.validateNumber({ integralPart: "123", fractionalPart: "" }), true, "#1");
-  assert.equal(maskInstance.validateNumber({ integralPart: "", fractionalPart: "123" }), true, "#2");
-  assert.equal(maskInstance.validateNumber({ integralPart: "123", fractionalPart: "456" }), true, "#3");
+  assert.equal(maskInstance.validateNumber({ integralPart: "123", fractionalPart: "" }, true), true, "#1");
+  assert.equal(maskInstance.validateNumber({ integralPart: "", fractionalPart: "123" }, true), true, "#2");
+  assert.equal(maskInstance.validateNumber({ integralPart: "123", fractionalPart: "456" }, true), true, "#3");
 
   maskInstance = new InputMaskNumeric();
   maskInstance.min = -100;
   maskInstance.max = 100;
-  assert.equal(maskInstance.validateNumber({ integralPart: "123", fractionalPart: "" }), false, "#4");
-  assert.equal(maskInstance.validateNumber({ integralPart: "", fractionalPart: "123" }), true, "#5");
-  assert.equal(maskInstance.validateNumber({ integralPart: "123", fractionalPart: "456" }), false, "#6");
+  assert.equal(maskInstance.validateNumber({ integralPart: "123", fractionalPart: "" }, true), false, "#4");
+  assert.equal(maskInstance.validateNumber({ integralPart: "", fractionalPart: "123" }, true), true, "#5");
+  assert.equal(maskInstance.validateNumber({ integralPart: "123", fractionalPart: "456" }, true), false, "#6");
 });
 
 QUnit.test("get numeric masked valid text", function(assert) {
@@ -464,6 +464,51 @@ QUnit.test("numeric processInput: min & max", function(assert) {
   result = maskInstance.processInput({ insertedChars: "", selectionStart: 1, selectionEnd: 2, prevValue: "-1", inputDirection: "forward" });
   assert.equal(result.value, "-", "remove 1");
   assert.equal(result.caretPosition, 1, "remove 1");
+});
+
+QUnit.test("numeric processInput: min 200", function(assert) {
+  const maskInstance = new InputMaskNumeric();
+  maskInstance.allowNegativeValues = true;
+  maskInstance.min = 200;
+
+  let result = maskInstance.processInput({ insertedChars: "-", selectionStart: 0, selectionEnd: 0, prevValue: "", inputDirection: "forward" });
+  assert.equal(result.value, "", "try insert minus");
+  assert.equal(result.caretPosition, 0, "try insert minus");
+
+  result = maskInstance.processInput({ insertedChars: "2", selectionStart: 1, selectionEnd: 1, prevValue: "", inputDirection: "forward" });
+  assert.equal(result.value, "2", "type 2");
+  assert.equal(result.caretPosition, 1, "type 2");
+
+  result = maskInstance.processInput({ insertedChars: "-", selectionStart: 1, selectionEnd: 1, prevValue: "2", inputDirection: "forward" });
+  assert.equal(result.value, "2", "try insert minus");
+  assert.equal(result.caretPosition, 1, "try insert minus");
+
+  result = maskInstance.processInput({ insertedChars: "1", selectionStart: 2, selectionEnd: 2, prevValue: "20", inputDirection: "forward" });
+  assert.equal(result.value, "201", "type 1");
+  assert.equal(result.caretPosition, 3, "type 1");
+});
+
+QUnit.test("numeric processInput: min 0 & max 100", function(assert) {
+  const maskInstance = new InputMaskNumeric();
+  maskInstance.allowNegativeValues = true;
+  maskInstance.min = 0;
+  maskInstance.max = 100;
+
+  let result = maskInstance.processInput({ insertedChars: "-", selectionStart: 0, selectionEnd: 0, prevValue: "", inputDirection: "forward" });
+  assert.equal(result.value, "", "try insert minus");
+  assert.equal(result.caretPosition, 0, "try insert minus");
+
+  result = maskInstance.processInput({ insertedChars: "2", selectionStart: 1, selectionEnd: 1, prevValue: "", inputDirection: "forward" });
+  assert.equal(result.value, "2", "type 2");
+  assert.equal(result.caretPosition, 1, "type 2");
+
+  result = maskInstance.processInput({ insertedChars: "-", selectionStart: 1, selectionEnd: 1, prevValue: "2", inputDirection: "forward" });
+  assert.equal(result.value, "2", "try insert minus");
+  assert.equal(result.caretPosition, 1, "try insert minus");
+
+  result = maskInstance.processInput({ insertedChars: "1", selectionStart: 2, selectionEnd: 2, prevValue: "99", inputDirection: "forward" });
+  assert.equal(result.value, "99", "try type 1");
+  assert.equal(result.caretPosition, 2, "try type 1");
 });
 
 QUnit.test("numeric processInput: precision", function(assert) {


### PR DESCRIPTION
Fixes #8037