### PR TITLE
Fixed #8085 - Image picker - The survey width mode doesn't change to responsive after setting column count that doesn't fix the container's static width value of 720px

### DIFF
--- a/src/question_imagepicker.ts
+++ b/src/question_imagepicker.ts
@@ -356,6 +356,9 @@ export class QuestionImagePickerModel extends QuestionCheckboxBase {
   protected needResponsiveness() {
     return this.supportResponsiveness() && this.isDefaultV2Theme;
   }
+  public needResponsiveWidth() {
+    return this.colCount > 2;
+  }
 
   private _width: number;
 

--- a/tests/surveyquestiontests.ts
+++ b/tests/surveyquestiontests.ts
@@ -7756,3 +7756,15 @@ QUnit.test("matrix.visibleRows and read-only", function (assert) {
   assert.equal(matrix.visibleRows[0].value, "col1", "row1.value");
   assert.equal(matrix.visibleRows[1].value, "col2", "row2.value");
 });
+QUnit.test("QuestionImagePickerModel.needResponsiveWidth", function (assert) {
+  const survey = new SurveyModel({
+    elements: [
+      { type: "imagepicker", name: "q" }
+    ]
+  });
+  const q = survey.getAllQuestions()[0] as QuestionImagePickerModel;
+  assert.equal(survey.widthMode, "auto", "Auto mode by default");
+  assert.equal(q.needResponsiveWidth(), false, "Not responsive for single column auto width mode");
+  q.colCount = 3;
+  assert.equal(q.needResponsiveWidth(), true, "Responsive in auto mode for several columns");
+});

--- a/visualRegressionTests/tests/defaultV2/imagepicker.ts
+++ b/visualRegressionTests/tests/defaultV2/imagepicker.ts
@@ -270,7 +270,8 @@ frameworks.forEach(framework => {
           }
         ],
         "showQuestionNumbers": "off",
-        "width": "1000"
+        "width": "1000",
+        "widthMode": "static"
       });
       const questionRoot = Selector(".sd-imagepicker");
       await takeElementScreenshot("imagepicker-question-columns-long-label.png", questionRoot, t, comparer);


### PR DESCRIPTION
Fixed #8085