### PR TITLE
Knockout: Text for carry forward choices are not changed immediately …

### DIFF
--- a/src/question_baseselect.ts
+++ b/src/question_baseselect.ts
@@ -151,6 +151,9 @@ export class QuestionSelectBase extends Question {
       ItemValue.locStrsChanged(this.choicesFromUrl);
       ItemValue.locStrsChanged(this.visibleChoices);
     }
+    if(this.isUsingCarryForward) {
+      ItemValue.locStrsChanged(this.visibleChoices);
+    }
   }
   public get otherValue(): string {
     if(!this.showCommentArea) return this.comment;

--- a/tests/question_baseselecttests.ts
+++ b/tests/question_baseselecttests.ts
@@ -1276,6 +1276,12 @@ QUnit.test("Carry Forward and localization, bug#6352", function (assert) {
   assert.equal(q2.visibleChoices.length, 1);
   assert.deepEqual(q2.visibleChoices[0].locText.getJson(), { default: "A de", en: "A en" });
   assert.equal(q2.visibleChoices[0].text, "A en");
+  let counter = 0;
+  q2.visibleChoices[0].locText.onStringChanged.add((sender, options) => {
+    counter ++;
+  });
+  survey.locale = "de";
+  assert.equal(counter, 1, "Fire str changed");
   surveyLocalization.defaultLocale = "en";
 });
 QUnit.test("Carry Forward and keepIncorrectValues, bug#6490", function (assert) {


### PR DESCRIPTION
…on changing survey locale fix #8367