### PR TITLE
chore: refactor setVariables to getVariables since it was a getter anyway

### DIFF
--- a/src/conditions.ts
+++ b/src/conditions.ts
@@ -68,11 +68,7 @@ export class ExpressionExecutor implements IExpresionExecutor {
       : false;
   }
   public getVariables(): Array<string> {
-    if (!this.operand) return [];
-
-    var variables: Array<string> = [];
-    this.operand.setVariables(variables);
-    return variables;
+    return this.operand?.getVariables() ?? [];
   }
 
   public hasFunction(): boolean {


### PR DESCRIPTION
The `Operand` base class defines a function `setVariables()` that is actually a getter.
This PR refactors `Operand` and it's concrete implementations to use a `getVariables(): Array<string>` getter.