### PR TITLE
#8773 A masked date time field does not return an expected value when using the currentDate function as a default value expression

### DIFF
--- a/packages/survey-core/src/mask/mask_base.ts
+++ b/packages/survey-core/src/mask/mask_base.ts
@@ -56,6 +56,10 @@ export class InputMaskBase extends Base implements IInputMask {
   public getUnmaskedValue(src: string): any { return src; }
   public getMaskedValue(src: any): string { return src; }
   public getTextAlignment(): "left" | "right" | "auto" { return "auto"; }
+
+  public getTypeForExpressions(): string {
+    return "text";
+  }
 }
 
 Serializer.addClass(

--- a/packages/survey-core/src/mask/mask_datetime.ts
+++ b/packages/survey-core/src/mask/mask_datetime.ts
@@ -185,6 +185,10 @@ export class InputMaskDateTime extends InputMaskPattern {
     return "datetimemask";
   }
 
+  public getTypeForExpressions(): string {
+    return this.hasTimePart ? "datetime-local" : "datetime";
+  }
+
   protected updateLiterals(): void {
     this.lexems = getDateTimeLexems(this.pattern || "");
   }

--- a/packages/survey-core/src/question_text.ts
+++ b/packages/survey-core/src/question_text.ts
@@ -433,7 +433,8 @@ export class QuestionTextModel extends QuestionTextBase {
     return isValid;
   }
   protected convertFuncValuetoQuestionValue(val: any): any {
-    return Helpers.convertValToQuestionVal(val, this.inputType);
+    let type = this.maskTypeIsEmpty ? this.inputType : this.maskSettings.getTypeForExpressions();
+    return Helpers.convertValToQuestionVal(val, type);
   }
   private getMinMaxErrorText(errorText: string, value: any): string {
     if (Helpers.isValueEmpty(value)) return errorText;

--- a/packages/survey-core/tests/question_texttests.ts
+++ b/packages/survey-core/tests/question_texttests.ts
@@ -5,6 +5,7 @@ import { QuestionTextBase, CharacterCounter } from "../src/question_textbase";
 import { settings } from "../src/settings";
 import { StylesManager } from "@legacy/stylesmanager";
 import { InputMaskPattern } from "../src/mask/mask_pattern";
+import { FunctionFactory } from "../src/functionsfactory";
 
 QUnit.test("check text disabled class", function (assert) {
   var json = {
@@ -516,4 +517,25 @@ QUnit.test("Mask is removed on loading, Bug#8624", function(assert) {
   const maskSettings = q1.maskSettings as InputMaskPattern;
   assert.equal(q1.maskType, "pattern", "mask type is set correctly");
   assert.equal(maskSettings.pattern, "999-99-999999", "pattern is loaded");
+});
+QUnit.test("Mask datetime with defaultValue as date", function (assert) {
+  function currentDateMock() {
+    return new Date("2024-09-04T12:34:00");
+  }
+  FunctionFactory.Instance.register("currentDateMock", currentDateMock);
+  const survey = new SurveyModel({
+    elements: [
+      {
+        "type": "text",
+        "name": "q1",
+        "defaultValueExpression": "currentDateMock()",
+        "maskType": "datetime",
+        "maskSettings": {
+          "pattern": "yyyy-mm-d HH:MM"
+        }
+      },
+    ]
+  });
+  const q1 = <QuestionTextModel>survey.getQuestionByName("q1");
+  assert.equal(q1.inputValue, "2024-09-4 12:34");
 });


### PR DESCRIPTION
Fixes #8773