### PR TITLE
Multi-Select Matrix - The 'Cannot read properties of null (reading 'l…

### DIFF
--- a/packages/survey-core/src/martixBase.ts
+++ b/packages/survey-core/src/martixBase.ts
@@ -154,7 +154,7 @@ export class QuestionMatrixBaseModel<TRow, TColumn> extends Question {
   protected isVisibleCore(): boolean {
     const res = super.isVisibleCore();
     if(!res || !(<any>this).hideIfRowsEmpty) return res;
-    return this.visibleRows.length > 0;
+    return this.visibleRows?.length > 0;
   }
   protected shouldRunColumnExpression(): boolean {
     return !this.survey || !this.survey.areInvisibleElementsShowing;

--- a/packages/survey-core/src/question_matrixdropdownbase.ts
+++ b/packages/survey-core/src/question_matrixdropdownbase.ts
@@ -1479,6 +1479,7 @@ export class QuestionMatrixDropdownModelBase extends QuestionMatrixBaseModel<Mat
       !Helpers.isTwoValueEquals(prevTotalValue, this.totalValue) &&
       counter < 3
     );
+    this.updateVisibilityBasedOnRows();
   }
   public runTriggers(name: string, value: any): void {
     super.runTriggers(name, value);

--- a/packages/survey-core/tests/question_matrixdynamictests.ts
+++ b/packages/survey-core/tests/question_matrixdynamictests.ts
@@ -8614,6 +8614,23 @@ QUnit.test("Test property hideIfRowsEmpty for matrix dropdown", function (assert
   survey.setValue("val1", 2);
   assert.equal(question.isVisible, true, "There is one visible item");
 });
+QUnit.test("Test property hideIfRowsEmpty for matrix dropdown on loading, Bug#8824", function (assert) {
+  var survey = new SurveyModel({
+    elements: [
+      { type: "text", name: "q1" },
+      { type: "matrixdropdown", name: "matrix", rowsVisibleIf: "{q1} != 'a'",
+        columns: [{ name: "col1", cellType: "text" }],
+        rows: ["row1", "row2"], hideIfRowsEmpty: true
+      }
+    ]
+  });
+  const matrix = survey.getQuestionByName("matrix");
+  assert.equal(matrix.getPropertyValue("isVisible"), true, "#1");
+  survey.setValue("q1", "a");
+  assert.equal(matrix.getPropertyValue("isVisible"), false, "#2");
+  survey.setValue("q1", "aa");
+  assert.equal(matrix.getPropertyValue("isVisible"), true, "#3");
+});
 
 QUnit.test("Load old JSON where columns without cellType set correctly", function (assert) {
   const survey = new SurveyModel({


### PR DESCRIPTION
…ength')' exception is thrown when hideIfRowsEmpty is enabled fix #8824