### PR TITLE
PR: Ranking order is lost when survey is reloaded

### DIFF
--- a/packages/survey-core/src/question_ranking.ts
+++ b/packages/survey-core/src/question_ranking.ts
@@ -182,6 +182,11 @@ export class QuestionRankingModel extends QuestionCheckboxModel {
     this.updateRankingChoices();
   };
 
+  updateValueFromSurvey(newValue: any, clearData: boolean): void {
+    super.updateValueFromSurvey(newValue, clearData);
+    if (newValue) this.isValueSetByUser = true;
+  }
+
   public localeChanged = (): void => {
     super.localeChanged();
     this.updateRankingChoicesSync();

--- a/packages/survey-core/tests/question_ranking_tests.ts
+++ b/packages/survey-core/tests/question_ranking_tests.ts
@@ -241,6 +241,34 @@ QUnit.test("Ranking: Carry Forward: Default Value", function(assert) {
   });
 });
 
+QUnit.test("Ranking: Carry Forward: Data", function(assert) {
+  var survey = new SurveyModel({
+    elements: [
+      {
+        "type": "checkbox",
+        "name": "q1",
+        "choices": [1, 2, 3, 4, 5]
+      },
+      {
+        "type": "ranking",
+        "name": "q2",
+        "choicesFromQuestion": "q1",
+        "choicesFromQuestionMode": "selected"
+      }
+    ]
+  });
+
+  survey.data = {
+    "q1": [1, 2, 3],
+    "q2": [3, 2, 1]
+  };
+
+  assert.deepEqual(survey.data, {
+    q1: [1, 2, 3],
+    q2: [3, 2, 1],
+  });
+});
+
 QUnit.test("Ranking: CorrectAnswer, Bug#3720", function(assert) {
   var survey = new SurveyModel({
     elements: [


### PR DESCRIPTION
work for the https://github.com/surveyjs/survey-library/issues/8836