### PR TITLE
Fixed #8882 'mobileHeight' does not exist in type 'IHeader'.ts

### DIFF
--- a/packages/survey-core/src/themes.ts
+++ b/packages/survey-core/src/themes.ts
@@ -94,9 +94,9 @@ export interface IHeader {
    */
   height: number;
   /**
-   * The height of the survey header in pixels on mobile devices.
+   * The height of the survey header on smartphones, measured in pixels.
    *
-   * Default value: 256
+   * Default value: 0 (the height is calculated automatically to accommodate the header's content).
    */
   mobileHeight?: number;
   /**

--- a/packages/survey-core/src/themes.ts
+++ b/packages/survey-core/src/themes.ts
@@ -94,6 +94,12 @@ export interface IHeader {
    */
   height: number;
   /**
+   * The height of the survey header in pixels on mobile devices.
+   *
+   * Default value: 256
+   */
+  mobileHeight?: number;
+  /**
    * A string value that specifies whether the header spans the width of the survey or that of the survey container.
    *
    * Possible values:


### PR DESCRIPTION
Fixed #8882