### PR TITLE
fix: frames disappearing when using root css config

### DIFF
--- a/packages/survey-core/src/survey-element.ts
+++ b/packages/survey-core/src/survey-element.ts
@@ -850,7 +850,7 @@ export class SurveyElement<E = any> extends SurveyElementCore implements ISurvey
   }
 
   public get isDefaultV2Theme() {
-    return this.survey && this.survey.getCss().root == "sd-root-modern";
+    return this.survey && this.survey.getCss().root.includes("sd-root-modern");
   }
 
   public get hasParent() {


### PR DESCRIPTION
I was seeing a strange issue where my question frames would randomly disappear when entering data into a survey.

After debugging I found that this was because I've created a custom feature that adds a css class to the survey root. 
Real code snippet:
```ts
combineLatest([
		observableProperty<boolean | null>(survey, 'themeShowBranding'),
		rootElement
	]).subscribe(([themeShowBranding, rootElement]) => {
		rootElement.classList.toggle('c-theme-branding', themeShowBranding ?? true);
		survey.css.root = themeShowBranding ? 'sd-root-modern c-theme-branding' : 'sd-root-modern';
	});
```

What I'm doing here is that when a custom survey property changes I update the current root element as well as the survey css settings (so any redraws, for example to due resizing) also add the proper classes.

However as soon as I change this setting, surveyjs things I'm no longer using a **default v2 theme**. I think it makes more sense to check for the presence of `.sd-root-modern` as opposed to it being the only class.

