### PR TITLE
fix - makes dropdown type of rating question display correct values on options

### DIFF
--- a/packages/survey-core/src/question_rating.ts
+++ b/packages/survey-core/src/question_rating.ts
@@ -37,8 +37,8 @@ export class RenderedRatingItem extends Base {
 }
 
 class RatingItemValue extends ItemValue {
-  constructor(value: any, public description: LocalizableString) {
-    super(value);
+  constructor(value: any, text: string = null, public description: LocalizableString) {
+    super(value, text);
   }
 }
 
@@ -403,7 +403,7 @@ export class QuestionRatingModel extends Question {
     if (value === this.rateMax || index === settings.ratingMaximumRateValueCount) {
       description = this.maxRateDescription && this.locMaxRateDescription;
     }
-    let newItem = new RatingItemValue(value, description);
+    let newItem = new RatingItemValue(value, item.text, description);
     newItem.locOwner = item.locOwner;
     newItem.ownerPropertyName = item.ownerPropertyName;
     return newItem;

--- a/packages/survey-react-ui/src/components/rating/rating-item.tsx
+++ b/packages/survey-react-ui/src/components/rating/rating-item.tsx
@@ -37,7 +37,14 @@ export class RatingItem extends RatingItemBase {
   render(): JSX.Element | null {
     var itemText = this.renderLocString(this.item.locText);
     return (
-      <label onMouseDown={this.handleOnMouseDown} className={this.question.getItemClassByText(this.item.itemValue, this.item.text)}>
+      <label
+        onMouseDown={this.handleOnMouseDown}
+        className={this.question.getItemClassByText(
+          this.item.itemValue,
+          this.item.text
+        )}
+      >
+        5555
         <input
           type="radio"
           className="sv-visuallyhidden"
@@ -48,13 +55,18 @@ export class RatingItem extends RatingItemBase {
           readOnly={this.question.isReadOnlyAttr}
           checked={this.question.value == this.item.value}
           onClick={this.props.handleOnClick}
-          onChange={() => { }}
+          onChange={() => {}}
           aria-required={this.question.ariaRequired}
           aria-label={this.question.ariaLabel}
           aria-invalid={this.question.ariaInvalid}
           aria-errormessage={this.question.ariaErrormessage}
         />
-        <span className={this.question.cssClasses.itemText} data-text={this.item.text}>{itemText}</span>
+        <span
+          className={this.question.cssClasses.itemText}
+          data-text={this.item.text}
+        >
+          {itemText}
+        </span>
       </label>
     );
   }

--- a/packages/survey-react-ui/src/components/rating/rating-item.tsx
+++ b/packages/survey-react-ui/src/components/rating/rating-item.tsx
@@ -44,7 +44,6 @@ export class RatingItem extends RatingItemBase {
           this.item.text
         )}
       >
-        5555
         <input
           type="radio"
           className="sv-visuallyhidden"


### PR DESCRIPTION
Rating questions can be turned into dropdowns when the screen width is not enough to fit all answers. When using dropdowns, values were used instead of text for dropdown options.