### PR TITLE
Dynamic Matrix - "defaultValueExpression": "{rowIndex}" always shows …

### DIFF
--- a/packages/survey-core/src/question.ts
+++ b/packages/survey-core/src/question.ts
@@ -2522,8 +2522,11 @@ export class Question extends SurveyElement<Question>
       if (this.isValueEmpty(value) && Helpers.isNumber(this[propName])) {
         value = 0;
       }
-      this[propName] = value;
+      this.updateBindingProp(propName, value);
     }
+  }
+  protected updateBindingProp(propName: string, value: any): void {
+    this[propName] = value;
   }
   public getComponentName(): string {
     return RendererFactory.Instance.getRendererByQuestion(this);

--- a/packages/survey-core/src/question_matrixdropdownbase.ts
+++ b/packages/survey-core/src/question_matrixdropdownbase.ts
@@ -414,9 +414,8 @@ export class MatrixDropdownRowModelBase implements ISurveyData, ISurveyImpl, ILo
     res[MatrixDropdownRowModelBase.RowValueVariableName] = this.rowName;
   }
   public runCondition(values: HashTable<any>, properties: HashTable<any>, rowsVisibleIf?: string): void {
-    if (!!this.data) {
-      values[MatrixDropdownRowModelBase.OwnerVariableName] = this.data.getFilteredData();
-    }
+    if(!this.data) return;
+    values[MatrixDropdownRowModelBase.OwnerVariableName] = this.data.getFilteredData();
     const rowIndex = this.rowIndex;
     this.applyRowVariablesToValues(values, rowIndex);
     const newProps = Helpers.createCopy(properties);
@@ -831,6 +830,9 @@ export class MatrixDropdownRowModelBase implements ISurveyData, ISurveyImpl, ILo
     return this.textPreProcessor;
   }
   public get rowIndex(): number {
+    return this.getRowIndex();
+  }
+  protected getRowIndex(): number {
     return !!this.data ? this.data.getRowIndex(this) + 1 : -1;
   }
   public get editingObj(): Base {
@@ -1442,9 +1444,9 @@ export class QuestionMatrixDropdownModelBase extends QuestionMatrixBaseModel<Mat
     return !!question ? question.getConditionJson(operator) : null;
   }
   public clearIncorrectValues(): void {
-    var rows = this.visibleRows;
-    if (!rows) return;
-    for (var i = 0; i < rows.length; i++) {
+    if (!Array.isArray(this.visibleRows)) return;
+    const rows = this.generatedVisibleRows;
+    for (let i = 0; i < rows.length; i++) {
       rows[i].clearIncorrectValues(this.getRowValue(i));
     }
   }
@@ -1794,12 +1796,12 @@ export class QuestionMatrixDropdownModelBase extends QuestionMatrixBaseModel<Mat
    * @param rowIndex A zero-based row index.
    * @see setRowValue
    */
-  public getRowValue(rowIndex: number) {
-    if (rowIndex < 0) return null;
-    var visRows = this.visibleRows;
-    if (rowIndex >= visRows.length) return null;
+  public getRowValue(rowIndex: number): any {
+    if (rowIndex < 0 || !Array.isArray(this.visibleRows)) return null;
+    var rows = this.generatedVisibleRows;
+    if (rowIndex >= rows.length) return null;
     var newValue = this.createNewValue();
-    return this.getRowValueCore(visRows[rowIndex], newValue);
+    return this.getRowValueCore(rows[rowIndex], newValue);
   }
   public checkIfValueInRowDuplicated(
     checkedRow: MatrixDropdownRowModelBase,
@@ -2456,8 +2458,8 @@ export class QuestionMatrixDropdownModelBase extends QuestionMatrixBaseModel<Mat
     return { value: newValue, rowValue: rowValue };
   }
   getRowIndex(row: MatrixDropdownRowModelBase): number {
-    if (!this.generatedVisibleRows) return -1;
-    return this.visibleRows.indexOf(row);
+    if (!Array.isArray(this.generatedVisibleRows)) return -1;
+    return this.generatedVisibleRows.indexOf(row);
   }
   public getElementsInDesign(includeHidden: boolean = false): Array<IElement> {
     let elements: Array<IElement>;

--- a/packages/survey-core/src/question_matrixdynamic.ts
+++ b/packages/survey-core/src/question_matrixdynamic.ts
@@ -25,6 +25,10 @@ export class MatrixDynamicRowModel extends MatrixDropdownRowModelBase implements
     super(data, value);
     this.buildCells(value);
   }
+  protected getRowIndex(): number {
+    const res = super.getRowIndex();
+    return res > 0 ? res : this.index + 1;
+  }
   public get rowName() {
     return this.id;
   }
@@ -222,6 +226,7 @@ export class QuestionMatrixDynamicModel extends QuestionMatrixDropdownModelBase
     return this.rowCountValue;
   }
   public set rowCount(val: number) {
+    val = Helpers.getNumber(val);
     if (val < 0 || val > settings.matrix.maxRowCount) return;
     this.setRowCountValueFromData = false;
     var prevValue = this.rowCountValue;
@@ -249,6 +254,22 @@ export class QuestionMatrixDynamicModel extends QuestionMatrixDropdownModelBase
       this.runCondition(this.getDataFilteredValues(), this.getDataFilteredProperties());
     }
     this.onRowsChanged();
+  }
+  protected updateBindingProp(propName: string, value: any): void {
+    super.updateBindingProp(propName, value);
+    const rows = this.generatedVisibleRows;
+    if(propName !== "rowCount" || !Array.isArray(rows)) return;
+    const val = this.getUnbindValue(this.value) || [];
+    if(val.length < rows.length) {
+      let hasValue = false;
+      for(let i = val.length; i < rows.length; i ++) {
+        hasValue ||= !rows[i].isEmpty;
+        val.push(rows[i].value || {});
+      }
+      if(hasValue) {
+        this.value = val;
+      }
+    }
   }
   protected updateProgressInfoByValues(res: IProgressInfo): void {
     let val = this.value;

--- a/packages/survey-core/tests/bindablePropertiesTests.ts
+++ b/packages/survey-core/tests/bindablePropertiesTests.ts
@@ -289,5 +289,6 @@ QUnit.test("Dynamic Matrix, bind rowCount and expression column", function (asse
   assert.equal(matrix.rowCount, 0, "row count is 0 by default");
   survey.setValue("q1", 3);
   assert.equal(matrix.rowCount, 3, "bindable question value is 3");
+  assert.equal(matrix.visibleRows.length, 3, "visible rows is 3");
   assert.deepEqual(matrix.value, [{ col1: "Row 1" }, { col1: "Row 2" }, { col1: "Row 3" }], "expression set correct value");
 });

--- a/packages/survey-core/tests/question_matrixdropdownbasetests.ts
+++ b/packages/survey-core/tests/question_matrixdropdownbasetests.ts
@@ -1783,3 +1783,35 @@ QUnit.test("Support columnsVisibleIf property, Bug#8796", function (assert) {
   assert.equal(table.rows[1].cells.length, 1 + 2, "Row: the last column is invisible, #3");
   assert.equal(table.headerRow.cells[2].headers, "col2", "The last column is col2, #3");
 });
+QUnit.test("rowVisibleIf & rowIndex, Bug#8796", function (assert) {
+  const survey = new SurveyModel({
+    elements: [
+      {
+        "type": "matrixdynamic",
+        "name": "matrix",
+        "rowsVisibleIf": "{row.no} = 1 or {row.no} empty",
+        "columns": [
+          {
+            "name": "no",
+            "cellType": "text",
+            "defaultValueExpression": "{rowIndex}"
+          },
+          {
+            "name": "column1"
+          },
+          {
+            "name": "column2",
+            "cellType": "expression",
+            "expression": "{rowIndex}"
+          }
+        ]
+      }
+    ]
+  });
+  const matrix = <QuestionMatrixDropdownModelBase>survey.getQuestionByName("matrix");
+  assert.equal(matrix.visibleRows.length, 1, "The first row is visible only");
+  matrix.addRow();
+  matrix.addRow();
+  assert.equal(matrix.visibleRows.length, 1, "The first row is visible only, #2");
+  assert.deepEqual(matrix.value, [{ no: 1, column2: 1 }, { no: 2, column2: 2 }, { no: 3, column2: 3 }, { no: 4, column2: 4 }], "matrix.data");
+});


### PR DESCRIPTION
…1 when the "rowsVisibleIf" expression is enabled fix #8920