### PR TITLE
FireFox: An incomplete date is considered valid when only its first p…

### DIFF
--- a/packages/survey-core/src/question_text.ts
+++ b/packages/survey-core/src/question_text.ts
@@ -641,6 +641,7 @@ export class QuestionTextModel extends QuestionTextBase {
     this.updateRemainingCharacterCounter(event.target.value);
   };
   protected onBlurCore(event: any): void {
+    this.updateDateValidationMessage(event);
     this.updateValueOnEvent(event);
     this.updateRemainingCharacterCounter(event.target.value);
     super.onBlurCore(event);


### PR DESCRIPTION
…art (for example, month) is entered fix #8840