### PR TITLE
Dynamic Matrix with Signature Pad in a detail form - The Clear button…

### DIFF
--- a/packages/survey-core/src/question_matrixdropdownbase.ts
+++ b/packages/survey-core/src/question_matrixdropdownbase.ts
@@ -2447,21 +2447,15 @@ export class QuestionMatrixDropdownModelBase extends QuestionMatrixBaseModel<Mat
       this.isValueInColumnDuplicated(columnName, !!rowObj);
     }
   }
-  private getNewValueOnRowChanged(
-    row: MatrixDropdownRowModelBase,
-    columnName: string,
-    newRowValue: any,
-    isDeletingValue: boolean,
-    newValue: any
-  ): any {
-    var rowValue = this.getRowValueCore(row, newValue, true);
+  private getNewValueOnRowChanged(row: MatrixDropdownRowModelBase,
+    columnName: string, newRowValue: any, isDeletingValue: boolean, newValue: any): any {
+    const rowValue = this.getRowValueCore(row, newValue, true);
     if (isDeletingValue) {
       delete rowValue[columnName];
     }
-    for (var i = 0; i < row.cells.length; i++) {
-      var key = row.cells[i].question.getValueName();
-      delete rowValue[key];
-    }
+    row.questions.forEach(q => {
+      delete rowValue[q.getValueName()];
+    });
     if (newRowValue) {
       newRowValue = JSON.parse(JSON.stringify(newRowValue));
       for (var key in newRowValue) {

--- a/packages/survey-core/tests/question_matrixdynamictests.ts
+++ b/packages/survey-core/tests/question_matrixdynamictests.ts
@@ -7309,6 +7309,37 @@ QUnit.test("Detail panel, Process text in titles", function (assert) {
     "Text preprocessed correctly"
   );
 });
+QUnit.test("Detail panel & survey.onValueChanged & empty value, Bug#9169", function (assert) {
+  const survey = new SurveyModel({
+    elements: [
+      {
+        type: "matrixdynamic",
+        name: "matrix",
+        rowCount: 2,
+        detailPanelMode: "underRow",
+        columns: [{ name: "col1" }, { name: "col2" }],
+        detailElements: [
+          { type: "text", name: "q1" }
+        ]
+      }
+    ]
+  });
+  const matrix = <QuestionMatrixDynamicModel>survey.getQuestionByName("matrix");
+
+  matrix.visibleRows[0].showDetailPanel();
+  const q1 = matrix.visibleRows[0].detailPanel.getQuestionByName("q1");
+  const logs: any = [];
+  survey.onValueChanged.add((sender, options) => {
+    logs.push({ name: options.name, value: options.value });
+  });
+  q1.value = "abc";
+  assert.deepEqual(logs, [{ name: "matrix", value: [{ q1: "abc" }, {}] }], "#1");
+  q1.clearValue();
+  assert.deepEqual(logs, [
+    { name: "matrix", value: [{ q1: "abc" }, {}] },
+    { name: "matrix", value: [] }
+  ], "#2");
+});
 
 QUnit.test("copyvalue trigger for dropdown matrix cell", function (assert) {
   var survey = new SurveyModel({


### PR DESCRIPTION
… doesn't invoke the survey.onValueChanged event when Signature Pad is placed within a detail form fix #9169