### PR TITLE
The survey.onValidatedErrorsOnCurrentPage function is not raised when…

### DIFF
--- a/packages/survey-core/src/survey.ts
+++ b/packages/survey-core/src/survey.ts
@@ -3427,7 +3427,8 @@ export class SurveyModel extends SurveyElementCore
       this.currentPageNo = index;
       return true;
     }
-    for (let i = this.currentPageNo; i < index; i++) {
+    if(!this.validateCurrentPage()) return false;
+    for (let i = this.currentPageNo + 1; i < index; i++) {
       const page = this.visiblePages[i];
       if (!page.validate(true, true)) return false;
       page.passed = true;

--- a/packages/survey-core/tests/surveyTOCTests.ts
+++ b/packages/survey-core/tests/surveyTOCTests.ts
@@ -641,3 +641,63 @@ QUnit.test("survey.tryNavigateToPage respects validationAllowSwitchPages and val
   assert.equal(survey.tryNavigateToPage(survey.pages[1]), true, "navigate #9");
   assert.equal(survey.currentPageNo, 1, "currentPageNo #2");
 });
+QUnit.test("survey.tryNavigateToPage & survey.onValidatedErrorsOnCurrentPage, Bug#9241", function (assert) {
+  let json: any = {
+    "pages": [
+      {
+        "name": "page1",
+        "elements": [
+          {
+            "type": "text",
+            "name": "question1",
+            "isRequired": true
+          }
+        ]
+      },
+      {
+        "name": "page2",
+        "elements": [
+          {
+            "type": "text",
+            "name": "question2",
+            "isRequired": true
+          }
+        ]
+      },
+      {
+        "name": "page3",
+        "elements": [
+          {
+            "type": "text",
+            "name": "question3",
+            "isRequired": true
+          }
+        ]
+      }
+    ]
+  };
+  const survey = new SurveyModel(json);
+  const logs = new Array<string>();
+  survey.onValidatedErrorsOnCurrentPage.add((sender, options) => {
+    logs.push(options.page.name);
+  });
+  assert.equal(survey.tryNavigateToPage(survey.pages[1]), false, "try #1");
+  assert.deepEqual(logs, ["page1"], "logs #1");
+  survey.setValue("question1", "val1");
+  assert.equal(survey.tryNavigateToPage(survey.pages[1]), true, "try #2");
+  assert.deepEqual(logs, ["page1", "page1"], "logs #2");
+  assert.equal(survey.tryNavigateToPage(survey.pages[0]), true, "try #3");
+  assert.deepEqual(logs, ["page1", "page1"], "logs #3");
+  assert.equal(survey.tryNavigateToPage(survey.pages[2]), false, "try #4");
+  assert.equal(survey.currentPageNo, 1, "currentPageNo #4");
+  assert.deepEqual(logs, ["page1", "page1", "page1"], "logs #4");
+  assert.equal(survey.tryNavigateToPage(survey.pages[1]), false, "try #5");
+  assert.deepEqual(logs, ["page1", "page1", "page1"], "logs #5");
+  assert.equal(survey.tryNavigateToPage(survey.pages[2]), false, "try #6");
+  assert.deepEqual(logs, ["page1", "page1", "page1", "page2"], "logs #6");
+  survey.setValue("question2", "val2");
+  assert.equal(survey.tryNavigateToPage(survey.pages[2]), true, "try #7");
+  assert.deepEqual(logs, ["page1", "page1", "page1", "page2", "page2"], "logs #7");
+  assert.equal(survey.tryNavigateToPage(survey.pages[0]), true, "try #8");
+  assert.deepEqual(logs, ["page1", "page1", "page1", "page2", "page2"], "logs #8");
+});


### PR DESCRIPTION
… a user attempts to navigate to another page using Table Of Contens when a page contains validation errors fix #9241