### PR TITLE
VueJs(complete page): place completePage content between header / footer

### DIFF
--- a/packages/survey-vue3-ui/src/Survey.vue
+++ b/packages/survey-vue3-ui/src/Survey.vue
@@ -86,12 +86,6 @@
               ></SvComponent>
             </div>
           </template>
-          <SvComponent
-            :is="'sv-components-container'"
-            :survey="vueSurvey"
-            :container="'footer'"
-            :needRenderWrapper="false"
-          ></SvComponent>
           <div v-if="hasCompletedPage">
             <div
               v-html="getProcessedCompletedHtml()"
@@ -104,6 +98,12 @@
               :needRenderWrapper="true"
             ></SvComponent>
           </div>
+          <SvComponent
+            :is="'sv-components-container'"
+            :survey="vueSurvey"
+            :container="'footer'"
+            :needRenderWrapper="false"
+          ></SvComponent>
           <div
             v-if="vueSurvey.state === 'completedbefore'"
             :class="vueSurvey.completedBeforeCss"


### PR DESCRIPTION
## Improvement

The completePage content is not between the slot `header` / `footer` available with `addLayoutElement`.

Move completePage content between the previous slot.