### PR TITLE
PR: [survey-angular-ui] The Cannot read properties of undefined (reading 'id') exception is thrown when implementing the survey.onAfterRenderQuestionInput functiuon

### DIFF
--- a/packages/survey-core/src/survey.ts
+++ b/packages/survey-core/src/survey.ts
@@ -5333,7 +5333,7 @@ export class SurveyModel extends SurveyElementCore
     if (this.onAfterRenderQuestionInput.isEmpty) return;
     let id = (<Question>question).inputId;
     const { root } = settings.environment;
-    if (!!id && htmlElement.id !== id && typeof root !== "undefined") {
+    if (!!id && (!htmlElement || htmlElement.id !== id) && typeof root !== "undefined") {
       let el = root.getElementById(id);
       if (!!el) {
         htmlElement = el;


### PR DESCRIPTION
work for the https://github.com/surveyjs/survey-library/issues/9349