### PR TITLE
Inelegant fix to: Specialized question type + showOtherItem doesn't show stored comment value #9374

### DIFF
--- a/packages/survey-core/src/question_custom.ts
+++ b/packages/survey-core/src/question_custom.ts
@@ -842,6 +842,9 @@ export class QuestionCustomModel extends QuestionCustomModelBase {
       this.setValue(this.name, this.value, false, this.allowNotifyValueChanged);
     }
   }
+  public supportOther(): boolean {
+    return true;
+  }
   public hasErrors(fireCallback: boolean = true, rec: any = null): boolean {
     if (!this.contentQuestion) return false;
     var res = this.contentQuestion.hasErrors(fireCallback, rec);
@@ -879,6 +882,9 @@ export class QuestionCustomModel extends QuestionCustomModelBase {
       let qType = json.questionJSON.type;
       if (!qType || !Serializer.findClass(qType))
         throw "type attribute in questionJSON is empty or incorrect";
+      if (json.questionJSON.showOtherItem !== undefined) {
+        this.showOtherItem = json.questionJSON.showOtherItem
+      }
       res = <Question>Serializer.createClass(qType);
       res.fromJSON(json.questionJSON);
       res = this.checkCreatedQuestion(res);

--- a/packages/survey-core/tests/question_customtests.ts
+++ b/packages/survey-core/tests/question_customtests.ts
@@ -3491,6 +3491,60 @@ QUnit.test("Composite: with dropdown & showOtherItem, Bug#9378", function (asser
 
   ComponentCollection.Instance.clear();
 });
+QUnit.test("Single: with dropdown & showOtherItem, Bug#9374", function (assert) {
+  ComponentCollection.Instance.add({
+    name: "test",  
+    questionJSON: {
+      type: "dropdown",
+      choices: [1, 2, 3],
+      showOtherItem: true
+    },
+  });
+  const survey = new SurveyModel({
+    elements: [
+      { type: "test", name: "question1" }
+    ]
+  });
+  const q = <QuestionCompositeModel>survey.getQuestionByName("question1");
+  q.value = "other";
+  q.comment = "abc";
+  assert.equal(q.value, "other", "q.value #1");
+  assert.equal(q.comment, "abc", "q.comment #1");
+  survey.data = {};
+  assert.ok(q.isEmpty(), "q.value #2");
+  survey.data = { question1: "other", "question1-Comment": "def" };
+  assert.equal(q.value, "other", "q.value #3");
+  assert.equal(q.comment, "def", "q.comment #3");
+
+  ComponentCollection.Instance.clear();
+});
+QUnit.test("Single: with dropdown & showOtherItem on definition, Bug#9374", function (assert) {
+  ComponentCollection.Instance.add({
+    name: "test",  
+    inheritBaseProps: ["showOtherItem"],
+    questionJSON: {
+      type: "dropdown",
+      choices: [1, 2, 3]
+    },
+  });
+  const survey = new SurveyModel({
+    elements: [
+      { type: "test", name: "question1", showOtherItem: true }
+    ]
+  });
+  const q = <QuestionCompositeModel>survey.getQuestionByName("question1");
+  q.value = "other";
+  q.comment = "abc";
+  assert.equal(q.value, "other", "q.value #1");
+  assert.equal(q.comment, "abc", "q.comment #1");
+  survey.data = {};
+  assert.ok(q.isEmpty(), "q.value #2");
+  survey.data = { question1: "other", "question1-Comment": "def" };
+  assert.equal(q.value, "other", "q.value #3");
+  assert.equal(q.comment, "def", "q.comment #3");
+
+  ComponentCollection.Instance.clear();
+});
 
 QUnit.test("Composite: checkErrorsMode: `onComplete` with several elements, Bug#9361", function (assert) {
   ComponentCollection.Instance.add({


### PR DESCRIPTION
I identified the source of the issue #9374, but I haven't found an elegant solution.

The issue is that `q.requireUpdateCommentValue` does not return the correct value, which prevents `q.updateCommentFromSurvey` from being called within `SurveyModel.updateAllQuestionsValue`.

This is a workaround that solves the problem, although it might not be the most elegant and could potentially cause issues in the future.