### PR TITLE
fix: export ExpressionItem

### DIFF
--- a/packages/survey-core/entries/chunks/model.ts
+++ b/packages/survey-core/entries/chunks/model.ts
@@ -125,7 +125,7 @@ export {
   LocalizableString,
   LocalizableStrings
 } from "../../src/localizablestring";
-export { HtmlConditionItem, UrlConditionItem } from "../../src/expressionItems";
+export * from "../../src/expressionItems";
 export { ChoicesRestful, ChoicesRestfull } from "../../src/choicesRestful";
 export { FunctionFactory, registerFunction } from "../../src/functionsfactory";
 export { ConditionRunner, ExpressionRunner, IExpresionExecutor, ExpressionExecutor } from "../../src/conditions";


### PR DESCRIPTION
`ExpressionItem` is not exported in the new fesm format.