### PR TITLE
chore: update currentSingleElement to be a union type that includes undefined

### DIFF
--- a/packages/survey-core/src/base-interfaces.ts
+++ b/packages/survey-core/src/base-interfaces.ts
@@ -109,7 +109,7 @@ export interface ISurvey extends ITextProcessor, ISurveyErrorOwner {
   isDisplayMode: boolean;
   isDesignMode: boolean;
   areInvisibleElementsShowing: boolean;
-  currentSingleElement: IElement;
+  currentSingleElement: IElement|undefined;
   areEmptyElementsHidden: boolean;
   isLoadingFromJson: boolean;
   isUpdateValueTextOnTyping: boolean;

--- a/packages/survey-core/src/survey.ts
+++ b/packages/survey-core/src/survey.ts
@@ -4713,7 +4713,7 @@ export class SurveyModel extends SurveyElementCore
     });
     this.updateButtonsVisibility();
   }
-  private currentSingleElementValue: IElement;
+  private currentSingleElementValue: IElement|undefined;
   private getSingleQuestions(): Array<IElement> {
     const res = new Array<IElement>();
     const pages = this.pages;
@@ -4728,7 +4728,7 @@ export class SurveyModel extends SurveyElementCore
     }
     return res;
   }
-  public get currentSingleElement(): IElement {
+  public get currentSingleElement(): IElement|undefined {
     return !this.isShowingPreview ? this.currentSingleElementValue : undefined;
   }
   public set currentSingleElement(val: IElement) {


### PR DESCRIPTION
The type for `currentSingleElement` suggests it is always set, but it is not.