### PR TITLE
[Vue3] The Header is not rendered when a survey is loaded asynchronously within the `onMounted` hook

### DIFF
--- a/packages/survey-core/src/survey.ts
+++ b/packages/survey-core/src/survey.ts
@@ -6536,6 +6536,8 @@ export class SurveyModel extends SurveyElementCore
   }
   public fromJSON(json: any, options?: ILoadFromJSONOptions): void {
     if (!json) return;
+    this.resetHasLogo();
+    this.resetPropertyValue("titleIsEmpty");
     this.questionHashesClear();
     this.jsonErrors = null;
     this.sjsVersion = undefined;

--- a/packages/survey-core/tests/surveytests.ts
+++ b/packages/survey-core/tests/surveytests.ts
@@ -21980,7 +21980,7 @@ QUnit.test("Don't rise onPageAdded when mooving question", function (assert) {
   assert.equal(survey.pages[0].name, "page2", "page2 is the first page");
 });
 
-QUnit.only("Update hasTitle on load from JSON", function (assert) {
+QUnit.test("Update hasTitle on load from JSON", function (assert) {
   const survey = new SurveyModel();
   assert.equal(survey.hasTitle, false, "no title in empty survey");
   survey.fromJSON({

--- a/packages/survey-core/tests/surveytests.ts
+++ b/packages/survey-core/tests/surveytests.ts
@@ -21979,3 +21979,13 @@ QUnit.test("Don't rise onPageAdded when mooving question", function (assert) {
   assert.equal(pageAddedRaisedCount, 0, "onPageAdded is not raised");
   assert.equal(survey.pages[0].name, "page2", "page2 is the first page");
 });
+
+QUnit.only("Update hasTitle on load from JSON", function (assert) {
+  const survey = new SurveyModel();
+  assert.equal(survey.hasTitle, false, "no title in empty survey");
+  survey.fromJSON({
+    title: "title",
+    elements: [{ name: "q1", type: "text" }]
+  });
+  assert.equal(survey.hasTitle, true, "title presents");
+});


### PR DESCRIPTION
Fixes #9678