### PR TITLE
Advanced header is misaligned when static width is specified for a survey

### DIFF
--- a/packages/survey-core/src/header.ts
+++ b/packages/survey-core/src/header.ts
@@ -110,7 +110,10 @@ export class Cover extends Base {
   }
   private updateContentClasses(): void {
     const surveyWidthMode = !!this.survey && this.survey.calculateWidthMode();
-    this.maxWidth = this.inheritWidthFrom === "survey" && !!surveyWidthMode && surveyWidthMode === "static" && this.survey.renderedWidth;
+    this.maxWidth = this.inheritWidthFrom === "survey" && !!surveyWidthMode && surveyWidthMode === "static" && this.survey.width;
+    if (!!this.maxWidth) {
+      this.maxWidth = parseFloat(this.maxWidth.toString().replace("px", "")) + "px";
+    }
     this.contentClasses = new CssClassBuilder()
       .append("sv-header__content")
       .append("sv-header__content--static", this.inheritWidthFrom === "survey" && !!surveyWidthMode && surveyWidthMode === "static")

--- a/packages/survey-core/tests/headerTests.ts
+++ b/packages/survey-core/tests/headerTests.ts
@@ -88,20 +88,31 @@ QUnit.test("contentClasses",
     cover.survey = new SurveyModel();
 
     assert.equal(cover.inheritWidthFrom, "survey", "default inheritWidthFrom");
+    assert.equal(cover.maxWidth, undefined, "default maxWidth");
 
     cover.inheritWidthFrom = "container";
     assert.equal(cover.inheritWidthFrom, "container", "inheritWidthFrom");
     assert.equal(cover.contentClasses, "sv-header__content sv-header__content--responsive", "inheritWidthFrom is container");
+    assert.equal(cover.maxWidth, "", "default maxWidth container");
 
     cover.inheritWidthFrom = "survey";
     assert.equal(cover.survey.widthMode, "auto", "default widthMode");
     assert.equal(cover.contentClasses, "sv-header__content sv-header__content--static", "default contentClasses");
+    assert.equal(cover.maxWidth, undefined, "default maxWidth survey");
 
     cover.survey.widthMode = "responsive";
     assert.equal(cover.contentClasses, "sv-header__content sv-header__content--responsive", "survey.widthMode is responsive");
+    assert.equal(cover.maxWidth, "", "default maxWidth survey responsible");
 
     cover.survey.widthMode = "static";
     assert.equal(cover.contentClasses, "sv-header__content sv-header__content--static", "survey.widthMode is static");
+    assert.equal(cover.maxWidth, undefined, "default maxWidth survey static");
+
+    cover.survey.width = "1200";
+    assert.equal(cover.maxWidth, "1200px", "default maxWidth survey static number");
+
+    cover.survey.width = "1200px";
+    assert.equal(cover.maxWidth, "1200px", "default maxWidth survey static px");
   }
 );
 


### PR DESCRIPTION
Fixes #9715