### PR TITLE
fix autoprefixer: end value has mixed support

### DIFF
--- a/packages/survey-core/src/default-theme/blocks/sd-matrixdynamic.scss
+++ b/packages/survey-core/src/default-theme/blocks/sd-matrixdynamic.scss
@@ -85,7 +85,7 @@
 .sd-table__cell.sd-table__cell--drag {
   >div {
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
     align-items: center;
     margin-left: calcSize(-4);
     width: calcSize(4);


### PR DESCRIPTION
Fix warning: **autoprefixer: end value has mixed support, consider using flex-end instead**

```
Import trace for requested module:
./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[13].oneOf[12].use[1]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[13].oneOf[12].use[2]!./node_modules/survey-core/survey-core.min.css
./node_modules/survey-core/survey-core.min.css
./src/components/SurveyWidget/index.tsx
./src/containers/Topic/index.tsx
 ⚠ ./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[13].oneOf[12].use[1]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[13].oneOf[12].use[2]!./node_modules/survey-core/survey-core.min.css
Warning

(6:99973) autoprefixer: end value has mixed support, consider using flex-end instead
```