### PR TITLE
#9880 Dynamic Matrix - The 'Add Row' Button is not displayed when Preview mode is activated from the first survey page before a matrix is rendered

### DIFF
--- a/packages/survey-core/src/question_matrixdropdownbase.ts
+++ b/packages/survey-core/src/question_matrixdropdownbase.ts
@@ -1585,6 +1585,7 @@ export class QuestionMatrixDropdownModelBase extends QuestionMatrixBaseModel<Mat
     if (!!rows) {
       rows.forEach(row => row.updateElementVisibility());
     }
+    this.updateShowTableAndAddRow();
   }
   protected shouldRunColumnExpression(): boolean {
     return false;

--- a/packages/survey-core/tests/surveyShowPreviewTests.ts
+++ b/packages/survey-core/tests/surveyShowPreviewTests.ts
@@ -828,3 +828,42 @@ QUnit.test("showAllQuestions - pages css after cancelPreview",
     assert.ok(survey.pages[1].cssClasses.page);
   }
 );
+
+QUnit.test("Add row button on showPreview",
+  function(assert) {
+    const survey = new SurveyModel({
+      "pages": [
+        {
+          "name": "page1",
+          "elements": [
+            {
+              "type": "text",
+              "name": "question1"
+            }
+          ]
+        },
+        {
+          "name": "page2",
+          "elements": [
+            {
+              "type": "matrixdynamic",
+              "name": "question2",
+              "columns": []
+            }
+          ]
+        }
+      ]
+    });
+    survey.showPreview();
+    assert.notOk(survey.getAllQuestions()[1].renderedTable.showAddRowOnBottom, "do not show AddRow on preview (matrix rendered first time)");
+    (<PanelModel>survey.currentPage.elements[0]).cancelPreview();
+    assert.ok(survey.getAllQuestions()[1].renderedTable.showAddRowOnBottom, "show AddRow on cancel preview");
+
+    survey.getAllQuestions()[1].resetRenderedTable();
+    assert.ok(survey.getAllQuestions()[1].renderedTable.showAddRowOnBottom, "show AddRow");
+    survey.showPreview();
+    assert.notOk(survey.getAllQuestions()[1].renderedTable.showAddRowOnBottom, "do not show AddRow on preview (matrix has been rendered already)");
+    (<PanelModel>survey.currentPage.elements[0]).cancelPreview();
+    assert.ok(survey.getAllQuestions()[1].renderedTable.showAddRowOnBottom, "show AddRow on cancel preview again");
+  }
+);


### PR DESCRIPTION
Fixes #9880