### PR TITLE
Specialized Question Types - The auto-advance feature doesn't work if…

### DIFF
--- a/packages/survey-core/src/question_custom.ts
+++ b/packages/survey-core/src/question_custom.ts
@@ -818,6 +818,9 @@ export class QuestionCustomModel extends QuestionCustomModelBase {
   protected getElement(): SurveyElement {
     return this.contentQuestion;
   }
+  supportAutoAdvance(): boolean {
+    return !!this.contentQuestion && this.contentQuestion.supportAutoAdvance();
+  }
   onAnyValueChanged(name: string, questionName: string): void {
     super.onAnyValueChanged(name, questionName);
     if (!!this.contentQuestion) {

--- a/packages/survey-core/tests/question_customtests.ts
+++ b/packages/survey-core/tests/question_customtests.ts
@@ -3731,3 +3731,19 @@ QUnit.test("Composite: text piping", function (assert) {
 
   ComponentCollection.Instance.clear();
 });
+QUnit.test("Single: supportAutoAdvance, bug#10149", function (assert) {
+  ComponentCollection.Instance.add({
+    name: "newquestion",
+    questionJSON: { type: "radiogroup", choices: [1, 2, 3], showOtherItem: true },
+  });
+  const survey = new SurveyModel({
+    elements: [{ type: "newquestion", name: "q1" }],
+  });
+  const q1 = <QuestionCustomModel>survey.getQuestionByName("q1");
+  assert.equal(q1.supportAutoAdvance(), false, "supportAutoAdvance #1");
+  q1.contentQuestion.onMouseDown();
+  assert.equal(q1.supportAutoAdvance(), true, "supportAutoAdvance #2");
+  q1.contentQuestion.value = "other";
+  assert.equal(q1.supportAutoAdvance(), false, "supportAutoAdvance #3");
+  ComponentCollection.Instance.clear();
+});


### PR DESCRIPTION
… a specialized question is built on top of any supported question type (e.g., Radiogroup) fix #10149