### PR TITLE
Fix schema for showPreviewBeforeComplete

### DIFF
--- a/packages/survey-core/docs/surveyjs_definition.json
+++ b/packages/survey-core/docs/surveyjs_definition.json
@@ -393,11 +393,16 @@
             "type": "boolean"
         },
         "showPreviewBeforeComplete": {
-            "type": "string",
+            "type": [
+                "string",
+                "boolean"
+            ],
             "enum": [
                 "noPreview",
                 "showAllQuestions",
-                "showAnsweredQuestions"
+                "showAnsweredQuestions",
+                true,
+                false
             ]
         },
         "showTimerPanel": {


### PR DESCRIPTION
Fix for the schema issue. Now the boolean is also allowed (it was allowed from some surveyjs version, but the schema was not reflecting this). Please see the related issue #10190 