### PR TITLE
Single-Select Matrix - A row's visibleIf expression doesn't evaluate …

### DIFF
--- a/packages/survey-core/src/calculatedValue.ts
+++ b/packages/survey-core/src/calculatedValue.ts
@@ -127,7 +127,10 @@ export class CalculatedValue extends Base {
     }
   }
   private ensureExpression() {
-    if (!!this.expressionRunner) return;
+    if (!!this.expressionRunner) {
+      this.expressionRunner.expression = this.expression;
+      return;
+    }
     this.expressionRunner = new ExpressionRunner(this.expression);
     this.expressionRunner.onRunComplete = newValue => {
       if (!Helpers.isTwoValueEquals(newValue, this.value, false, true, false)) {

--- a/packages/survey-core/src/martixBase.ts
+++ b/packages/survey-core/src/martixBase.ts
@@ -21,7 +21,6 @@ export class QuestionMatrixBaseModel<TRow, TColumn> extends Question {
 
   constructor(name: string) {
     super(name);
-    this.filteredRows = null;
     this.columns = this.createColumnValues();
     this.rows = this.createItemValues("rows");
   }
@@ -197,6 +196,9 @@ export class QuestionMatrixBaseModel<TRow, TColumn> extends Question {
     ItemValue.runEnabledConditionsForItems(this.rows, undefined, properties);
     if (this.filteredRows.length === this.rows.length) {
       this.filteredRows = null;
+      if (!!this.generatedVisibleRows && this.generatedVisibleRows.length !== this.rows.length) {
+        this.generatedVisibleRows = null;
+      }
     }
     return hasChanged;
   }

--- a/packages/survey-core/tests/question_matrix_tests.ts
+++ b/packages/survey-core/tests/question_matrix_tests.ts
@@ -494,7 +494,21 @@ QUnit.test("hideIfRowsEmpty & question visibleIf, bug#8459", function (assert) {
   survey.setValue("b", 2);
   assert.equal(question.isVisible, true, "#7");
 });
-
+QUnit.test("row visibleIf, bug#10222", function (assert) {
+  const survey = new SurveyModel({
+    elements: [{ type: "matrix", name: "q1",
+      rows: [{ value: "row1", visibleIf: "{var1}=2" }, "row2"] }],
+    calculatedValues: [{ name: "var1", expression: "2" }],
+  });
+  const calcValue = survey.calculatedValues[0];
+  assert.equal(calcValue.value, 2, "calcValue.value is 2");
+  const question = <QuestionMatrixModel>survey.getQuestionByName("q1");
+  assert.equal(question.rows.length, 2, "There are two rows");
+  assert.equal(question.visibleRows.length, 2, "There is one visible row");
+  calcValue.expression = "1";
+  assert.equal(calcValue.value, 1, "calcValue.value is 1");
+  assert.equal(question.visibleRows.length, 1, "There is one visible row after expression change");
+});
 QUnit.test("check displayMode property", function (assert) {
   const survey = new SurveyModel({ elements: { type: "matrix", name: "q1", rows: [{ value: "row1" }] } });
   const question = <QuestionMatrixModel>survey.getAllQuestions()[0];


### PR DESCRIPTION
…correctly when it includes a survey calculated field fix #10222