### PR TITLE
improve clearCaption translation for pt-br

### DIFF
--- a/packages/survey-core/src/localization/portuguese-br.ts
+++ b/packages/survey-core/src/localization/portuguese-br.ts
@@ -175,7 +175,6 @@ export var portugueseBrSurveyStrings = {
   timerLimitPage: "Você gastou {0} de {1} nesta página.",
   // [Auto-translated] "You have spent {0} of {1} in total."
   timerLimitSurvey: "Gastou {0} de {1} no total.",
-  // [Auto-translated] "Clear"
   clearCaption: "Excluir tudo",
   // [Auto-translated] "Select"
   selectCaption: "Selecionar",


### PR DESCRIPTION
I'm a native portuguese speaker and the former "Claro" translation seems a bit off in Portuguese, as in this context means "Bright/Light".

I changed the title to "Excluir tudo", which means "Delete all"