### PR TITLE
A choice's display text is not rendered in a dynamic panel's tab titl…

### DIFF
--- a/packages/survey-core/src/textPreProcessor.ts
+++ b/packages/survey-core/src/textPreProcessor.ts
@@ -135,9 +135,8 @@ export class TextContextProcessor extends TextPreProcessor {
     return this.context || this.obj;
   }
   private getProcessedTextValue(textValue: TextPreProcessorValue) {
-    const name = textValue.name.toLocaleLowerCase();
     const context = this.getContextObj();
-    const res = new ValueGetter().getValueInfo({ name: name, context: context.getValueGetterContext(), isText: true, isDisplayValue: textValue.returnDisplayValue });
+    const res = new ValueGetter().getValueInfo({ name: textValue.name, context: context.getValueGetterContext(), isText: true, isDisplayValue: textValue.returnDisplayValue });
     if (res.isFound) {
       textValue.isExists = res.isFound;
       textValue.value = res.value;

--- a/packages/survey-core/tests/question_baseselecttests.ts
+++ b/packages/survey-core/tests/question_baseselecttests.ts
@@ -794,10 +794,29 @@ QUnit.test("checkbox vs valuePropertyName, getDisplayValue", (assert) => {
     ]
   });
   const q = <QuestionCheckboxModel>survey.getQuestionByName("q1");
-  q.value = [1, 3];
   assert.deepEqual(q.getDisplayValue(false, [{ fruit: 1 }, { fruit: 3 }]), "apple, orange", "display value for all values");
-  //assert.deepEqual(q.getDisplayValue(false, [{ fruite: 1 }]), ["apple", "orange"], "display value for all values");
-  //assert.deepEqual(q.getDisplayValue(false), ["apple", "orange"], "display value for all values");
+});
+QUnit.test("checkbox vs valuePropertyName, getDisplayValue & value name uses uppercase letters, Bug#10707", (assert) => {
+  const survey = new SurveyModel({
+    elements: [
+      {
+        type: "checkbox",
+        name: "q1",
+        choices: [{ value: 1, text: "apple" }, { value: 2, text: "banana" }, { value: 3, text: "orange" }],
+        valuePropertyName: "fruitID"
+      },
+      {
+        type: "text",
+        name: "q2",
+        title: "{q1}"
+      }
+    ]
+  });
+  const q1 = <QuestionCheckboxModel>survey.getQuestionByName("q1");
+  assert.deepEqual(q1.getDisplayValue(false, [{ fruitID: 1 }, { fruitID: 3 }]), "apple, orange", "display value for all values");
+  q1.value = [{ fruitID: 2 }];
+  const q2 = survey.getQuestionByName("q2");
+  assert.equal(q2.locTitle.renderedHtml, "banana", "display value in text question");
 });
 QUnit.test("checkbox vs valuePropertyName, check showOtherItem vs storeOthersAsComment", (assert) => {
   const survey = new SurveyModel({

--- a/packages/survey-core/tests/question_paneldynamic_tests.ts
+++ b/packages/survey-core/tests/question_paneldynamic_tests.ts
@@ -5754,6 +5754,38 @@ QUnit.test("checkbox vs valuePropertyName and display text and useDisplayValuesI
   assert.equal(p1_q1.locTitle.renderedHtml, 1, "title for question in panel1");
   assert.equal(p2_q1.locTitle.renderedHtml, 3, "title for question in panel2");
 });
+QUnit.test("checkbox vs valuePropertyName and display text and valuePropertyName is in uppercase, Bug#10707", (assert) => {
+  const survey = new SurveyModel({
+    elements: [
+      {
+        type: "checkbox",
+        name: "q1",
+        choices: [{ value: 1, text: "apple" }, { value: 2, text: "banana" }, { value: 3, text: "orange" }],
+        valueName: "data1",
+        valuePropertyName: "fruitID"
+      },
+      {
+        type: "paneldynamic",
+        name: "panel",
+        valueName: "data1",
+        templateTitle: "{panel.fruitID}",
+        templateElements: [
+          { type: "text", name: "panel_q1", title: "{panel.fruitID}" },
+        ],
+      }
+    ]
+  });
+  const q = <QuestionCheckboxModel>survey.getQuestionByName("q1");
+  const panel = <QuestionPanelDynamicModel>survey.getQuestionByName("panel");
+  q.renderedValue = [1, 3];
+  assert.equal(panel.panelCount, 2, "There are two panels");
+  assert.equal(panel.panels[0].locTitle.renderedHtml, "apple", "panel1 title");
+  assert.equal(panel.panels[1].locTitle.renderedHtml, "orange", "panel2 title");
+  const p1_q1 = panel.panels[0].getQuestionByName("panel_q1");
+  const p2_q1 = panel.panels[1].getQuestionByName("panel_q1");
+  assert.equal(p1_q1.locTitle.renderedHtml, "apple", "title for question in panel1");
+  assert.equal(p2_q1.locTitle.renderedHtml, "orange", "title for question in panel2");
+});
 QUnit.test("checkbox vs valuePropertyName and rendering panels, Bug#10633", (assert) => {
   const survey = new SurveyModel({
     elements: [


### PR DESCRIPTION
…e when a value name uses uppercase letters fix #10707