### PR TITLE
Fix generateSchema() to output derived types for polymorphic single-object properties

### DIFF
--- a/packages/survey-core/tests/jsonSchemaTests.ts
+++ b/packages/survey-core/tests/jsonSchemaTests.ts
@@ -226,3 +226,41 @@ QUnit.test("generate survey schema", function (assert) {
   assert.deepEqual(customProp2.enum, ["a", "b"], "customProp2.enum");
   Serializer.removeProperty("survey", "customSurveyProperty2");
 });
+
+QUnit.test("generate schema with polymorphic single object properties (maskSettings)", function (assert) {
+  const schema = Serializer.generateSchema();
+  const textProps = schema.definitions.text.allOf[1].properties;
+  const maskSettingsProp = textProps.maskSettings;
+
+  assert.ok(maskSettingsProp, "maskSettings property exists on text question");
+  assert.ok(maskSettingsProp.oneOf, "maskSettings has oneOf for polymorphic types");
+  assert.ok(maskSettingsProp.oneOf.length >= 5, "maskSettings oneOf has base and derived types");
+
+  const refNames = maskSettingsProp.oneOf.map((item: any) => item.$ref);
+  assert.ok(refNames.includes("masksettings"), "masksettings base class is in oneOf");
+  assert.ok(refNames.includes("patternmask"), "patternmask is in oneOf");
+  assert.ok(refNames.includes("numericmask"), "numericmask is in oneOf");
+  assert.ok(refNames.includes("datetimemask"), "datetimemask is in oneOf");
+  assert.ok(refNames.includes("currencymask"), "currencymask is in oneOf");
+
+  assert.ok(schema.definitions.masksettings, "masksettings definition exists");
+  assert.ok(schema.definitions.patternmask, "patternmask definition exists");
+  assert.ok(schema.definitions.numericmask, "numericmask definition exists");
+  assert.ok(schema.definitions.datetimemask, "datetimemask definition exists");
+  assert.ok(schema.definitions.currencymask, "currencymask definition exists");
+
+  assert.ok(schema.definitions.patternmask.allOf, "patternmask has allOf for inheritance");
+  assert.equal(schema.definitions.patternmask.allOf[0].$ref, "masksettings", "patternmask extends masksettings");
+  assert.ok(schema.definitions.patternmask.allOf[1].properties.pattern, "patternmask has pattern property");
+
+  assert.ok(schema.definitions.numericmask.allOf, "numericmask has allOf for inheritance");
+  assert.equal(schema.definitions.numericmask.allOf[0].$ref, "masksettings", "numericmask extends masksettings");
+  assert.ok(schema.definitions.numericmask.allOf[1].properties.precision, "numericmask has precision property");
+
+  assert.ok(schema.definitions.datetimemask.allOf, "datetimemask has allOf for inheritance");
+  assert.equal(schema.definitions.datetimemask.allOf[0].$ref, "patternmask", "datetimemask extends patternmask");
+
+  assert.ok(schema.definitions.currencymask.allOf, "currencymask has allOf for inheritance");
+  assert.equal(schema.definitions.currencymask.allOf[0].$ref, "numericmask", "currencymask extends numericmask");
+  assert.ok(schema.definitions.currencymask.allOf[1].properties.prefix, "currencymask has prefix property");
+});


### PR DESCRIPTION
Fixes #10800

## Summary

`Serializer.generateSchema()` was not outputting derived types for polymorphic single-object properties like `maskSettings`. This fix ensures that:

- `maskSettings` now generates a `oneOf` schema with all derived mask types (`masksettings`, `patternmask`, `numericmask`, `datetimemask`, `currencymask`)
- All derived type definitions are included in the schema with proper `allOf` inheritance

## Problem

Previously, the schema for `maskSettings` was incorrectly generated as:
```json
{
  "type": "array",
  "items": { "$ref": "masksettings" }
}
```

This happened because:
1. `schemaType()` returned `"array"` for any property with `className`, regardless of the `isArray` flag
2. `generateSchemaProperty()` only output a simple `$ref` for non-array properties, without checking for derived classes

## Solution

**`schemaType()`**: Now checks `isArray` before returning `"array"` for className properties:
```typescript
if (!!this.className && this.isArray) return "array";  // was: if (!!this.className) return "array";
```

**`generateSchemaProperty()`**: For non-array properties with a className, checks if the class has derived types and generates a `oneOf` schema:
```typescript
const childClasses = this.getChildrenClasses(prop.className, true);
if (childClasses.length > 0) {
  res.oneOf = [{ $ref: this.getChemeRefName(prop.className, isRoot) }];
  for (i = 0; i < childClasses.length; i++) {
    res.oneOf.push({ $ref: this.getChemeRefName(childClasses[i].name, isRoot) });
    this.generateChemaClass(childClasses[i].name, schemaDef, false);
  }
} else {
  res["$ref"] = this.getChemeRefName(refType, isRoot);
}
```

## Result

`maskSettings` now correctly generates:
```json
{
  "oneOf": [
    { "$ref": "masksettings" },
    { "$ref": "patternmask" },
    { "$ref": "datetimemask" },
    { "$ref": "numericmask" },
    { "$ref": "currencymask" }
  ]
}
```

And all derived mask definitions are included with proper inheritance:
```json
{
  "patternmask": {
    "type": "object",
    "$id": "patternmask",
    "allOf": [
      { "$ref": "masksettings" },
      { "properties": { "pattern": { "type": "string" } } }
    ]
  }
}
```

## Test Plan

- [x] Added unit test verifying `maskSettings` has `oneOf` with all mask types
- [x] Added assertions for derived type definitions and inheritance
- [x] Existing `JsonSchemaTests` pass