### PR TITLE
validateExpressions() incorrectly reports UnknownVariable when using …

### DIFF
--- a/packages/survey-core/src/question_matrixdynamic.ts
+++ b/packages/survey-core/src/question_matrixdynamic.ts
@@ -33,7 +33,6 @@ export class MatrixDynamicValueGetterContext extends QuestionValueGetterContext 
     const index = params.index;
     const md = <QuestionMatrixDynamicModel>this.question;
     if (index > -1 && md.isDesignMode) return md.getDesignRowContext().getValue(params);
-    if (!params.createObjects && this.question.isEmpty()) return { isFound: path.length === 0, value: undefined };
     if (index > -1) {
       const rows = md.allRows;
       if (index >= 0 && index < rows.length) {
@@ -42,6 +41,7 @@ export class MatrixDynamicValueGetterContext extends QuestionValueGetterContext 
       }
       return { isFound: false, value: undefined, context: this };
     }
+    if (!params.createObjects && this.question.isEmpty()) return { isFound: path.length === 0, value: undefined };
     return super.getValue(params);
   }
 }

--- a/packages/survey-core/src/question_paneldynamic.ts
+++ b/packages/survey-core/src/question_paneldynamic.ts
@@ -146,7 +146,6 @@ export class PanelDynamicValueGetterContext extends QuestionValueGetterContext {
       }
       return { isFound: false };
     }
-    if (!params.createObjects && this.question.isEmpty()) return { isFound: path.length === 0, value: undefined };
     if (index > -1) {
       if (index >= 0 && index < pd.panels.length) {
         const item = <QuestionPanelDynamicItem>pd.panels[index].data;
@@ -155,6 +154,7 @@ export class PanelDynamicValueGetterContext extends QuestionValueGetterContext {
       }
       return { isFound: false, value: undefined, context: this };
     }
+    if (!params.createObjects && this.question.isEmpty()) return { isFound: path.length === 0, value: undefined };
     return super.getValue(params);
   }
 }

--- a/packages/survey-core/tests/expressions/expressionValidationTest.ts
+++ b/packages/survey-core/tests/expressions/expressionValidationTest.ts
@@ -747,3 +747,59 @@ QUnit.test("fromJSON & design mode - reports unknown variable inside paneldynami
   let result = survey.validateExpressions({ functions: true, variables: true, semantics: true });
   assert.equal(result.length, 0, "There are 0 invalid expressions");
 });
+QUnit.test("validate expressions in empty paneldynamic by arrays, but with set panelCount property, Bug#10841", (assert) => {
+  const survey = new SurveyModel();
+  survey.fromJSON({
+    elements: [
+      {
+        type: "paneldynamic",
+        name: "q1",
+        panelCount: 1,
+        templateElements: [
+          {
+            type: "text",
+            name: "q2",
+            inputType: "number",
+          },
+        ],
+      },
+      {
+        type: "expression",
+        name: "q3",
+        expression: "{q1[0].q2} notempty",
+      }
+    ],
+  });
+  const result = survey.validateExpression("expression", "{q1[0].q2} notempty", { functions: true, variables: true, semantics: true });
+  assert.equal(result, undefined, "There is no error in expression with paneldynamic array item");
+  let results = survey.validateExpressions({ functions: true, variables: true, semantics: true });
+  assert.equal(results.length, 0, "There are 0 invalid expressions");
+});
+QUnit.test("validate expressions in empty matrixdynamic by arrays, but with set rowCount property, Bug#10841", (assert) => {
+  const survey = new SurveyModel();
+  survey.fromJSON({
+    elements: [
+      {
+        type: "matrixdynamic",
+        name: "q1",
+        rowCount: 1,
+        columns: [
+          {
+            cellType: "text",
+            name: "q2",
+            inputType: "number",
+          },
+        ],
+      },
+      {
+        type: "expression",
+        name: "q3",
+        expression: "{q1[0].q2} notempty",
+      }
+    ],
+  });
+  const result = survey.validateExpression("expression", "{q1[0].q2} notempty", { functions: true, variables: true, semantics: true });
+  assert.equal(result, undefined, "There is no error in expression with paneldynamic array item");
+  let results = survey.validateExpressions({ functions: true, variables: true, semantics: true });
+  assert.equal(results.length, 0, "There are 0 invalid expressions");
+});


### PR DESCRIPTION
…[i] with PanelDynamic fix #10874