### PR TITLE
Fix: Update logic to prevent request sending when waiting for choices…

### DIFF
--- a/packages/survey-core/src/question_baseselect.ts
+++ b/packages/survey-core/src/question_baseselect.ts
@@ -645,7 +645,7 @@ export class QuestionSelectBase extends Question implements IChoiceOwner {
     return true; //for comments and others
   }
   protected setDefaultIntoValue(val: any): void {
-    if (!this.isValueEmpty(val) && this.showOtherItem && this.hasUnknownValue(val, true)) {
+    if (!this.isValueEmpty(val) && !this.waitingChoicesByURL && this.showOtherItem && this.hasUnknownValue(val, true)) {
       this.setDefaultUnknownValue(val);
     } else {
       super.setDefaultIntoValue(val);

--- a/packages/survey-core/tests/choicesRestfultests.ts
+++ b/packages/survey-core/tests/choicesRestfultests.ts
@@ -26,6 +26,7 @@ export default QUnit.module("choicesRestful");
 
 class ChoicesRestfulTester extends ChoicesRestful {
   private delaySentRequestValue: boolean = false;
+  public static doNotSendRequest = false;
   private nonProceedUrls = {};
   public noCaching: boolean = false;
   public lastProcesedUrl: string;
@@ -52,7 +53,7 @@ class ChoicesRestfulTester extends ChoicesRestful {
     if (this.isRequestRunning !== undefined) return this.isRequestRunning;
     return super.getIsRunning();
   }
-  public blockSendingRequest: boolean;
+  public blockSendingRequest: boolean = ChoicesRestfulTester.doNotSendRequest;
   public unblockSendRequest() {
     this.blockSendingRequest = undefined;
     this.sendRequest();
@@ -1361,7 +1362,26 @@ QUnit.test("Process text in url with default text, bug#1000", function(assert) {
     "The value is set correctly from defaultValue"
   );
 });
-
+QUnit.test("Process text in url with default text & showOtherItem, bug#10926", (assert) => {
+  ChoicesRestfulTester.doNotSendRequest = true;
+  const survey = new SurveyModel({
+    elements: [
+      {
+        type: "dropdownrestfultester",
+        name: "q1",
+        choicesByUrl: { url: "ca_cities" },
+        defaultValue: "Los Angeles",
+        showOtherItem: true
+      }
+    ],
+  });
+  const question = <QuestionDropdownModelTester>survey.getQuestionByName("q1");
+  assert.equal(question.visibleChoices.length, 1, "We have only other item on loading survey");
+  (<any>question.choicesByUrl).unblockSendRequest();
+  assert.equal(question.value, "Los Angeles", "The value is set correctly from defaultValue");
+  assert.equal(question.visibleChoices.length, 3, "We have two cities + other on loading survey, CA");
+  ChoicesRestfulTester.doNotSendRequest = false;
+});
 QUnit.test("Cascad dropdown in matrix dynamic", function(assert) {
   var survey = new SurveyModel();
   survey.addNewPage("1");


### PR DESCRIPTION
… in QuestionSelectBase, fix Dropdown - The `defaultValue` (`choice.value`) in ChoicesByUrl is resolved as “Other”

Fixes #10926