### PR TITLE
fix: clear other field error on value change

### DIFF
--- a/packages/survey-core/src/question_baseselect.ts
+++ b/packages/survey-core/src/question_baseselect.ts
@@ -370,7 +370,7 @@ export class QuestionSelectBase extends Question implements IChoiceOwner {
   private updatePrevOtherErrorValue(val: string): void {
     const oldVal = this.otherValue;
     if (val !== oldVal) {
-      this.prevOtherErrorValue = oldVal;
+      this.prevOtherErrorValue = oldVal || " ";
     }
   }
   private isSettingComment: boolean;


### PR DESCRIPTION
Fixes #10964

When  is set to , the required validation error for the Other field persisted after entering a value. This happened because  was set to an empty string (falsy) when there was no previous value, causing the validation condition to fail.

The fix uses a truthy value () when the old value was empty, ensuring the validation logic correctly clears the error when the user enters text in the Other field.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*