### PR TITLE
Clearing the Maximum question width property using Backspace doesn't reset it to the original value (100%) but keeps an empty value fix #11013

### DIFF
--- a/packages/survey-core/src/panel.ts
+++ b/packages/survey-core/src/panel.ts
@@ -2542,7 +2542,7 @@ Serializer.addClass(
     { name: "startWithNewLine:boolean", default: true },
     { name: "width" },
     { name: "minWidth", defaultFunc: () => "auto" },
-    { name: "maxWidth", defaultFunc: () => settings.maxWidth },
+    { name: "maxWidth", defaultFunc: () => settings.maxWidth, onSettingValue: (obj: any, val: any): any => { return val || undefined; } },
     { name: "colSpan:number", visible: false, onSerializeValue: (obj) => { return obj.getPropertyValue("colSpan"); } },
     {
       name: "effectiveColSpan:number", minValue: 1, isSerializable: false,

--- a/packages/survey-core/src/question.ts
+++ b/packages/survey-core/src/question.ts
@@ -3168,7 +3168,7 @@ Serializer.addClass("question", [
   "visibleIf:condition",
   { name: "width" },
   { name: "minWidth", defaultFunc: () => settings.minWidth },
-  { name: "maxWidth", defaultFunc: () => settings.maxWidth },
+  { name: "maxWidth", defaultFunc: () => settings.maxWidth, onSettingValue: (obj: any, val: any): any => { return val || undefined; } },
   {
     name: "colSpan:number", visible: false,
     onSerializeValue: (obj) => { return obj.getPropertyValue("colSpan"); },

--- a/packages/survey-core/tests/basetests.ts
+++ b/packages/survey-core/tests/basetests.ts
@@ -968,6 +968,14 @@ QUnit.test("check afterRerender function", (assert) => {
   survey.afterRerender();
   assert.equal(log, "");
 });
+QUnit.test("maxWidth should return to default when set to empty string", function (assert) {
+  const question = new QuestionDropdownModel("q1");
+  assert.equal(question.maxWidth, "100%", "maxWidth default value is 100%");
+  question.maxWidth = "50%";
+  assert.equal(question.maxWidth, "50%", "maxWidth is set to 50%");
+  question.maxWidth = "";
+  assert.equal(question.maxWidth, "100%", "maxWidth returns to default on empty string");
+});
 
 QUnit.test("check default value doesn't exist on getPropertyValueDirectly", (assert) => {
   Serializer.addProperty("itemvalue", {

--- a/packages/survey-core/tests/paneltests.ts
+++ b/packages/survey-core/tests/paneltests.ts
@@ -3828,3 +3828,16 @@ QUnit.test("Do not create gridLayoutColumns array on creating&loading/serializin
   assert.equal(panel.toJSON().name, "panel1");
   assert.equal(panel.getPropertyValue("gridLayoutColumns"), undefined, "gridLayoutColumns array is not created on serializing");
 });
+QUnit.test("Panel maxWidth should return to default when set to empty string", (assert) => {
+  const survey = new SurveyModel({
+    elements: [
+      { type: "panel", name: "panel1", elements: [{ type: "text", name: "q1" }] }
+    ]
+  });
+  const panel = survey.getPanelByName("panel1");
+  assert.equal(panel.maxWidth, settings.maxWidth, "panel maxWidth default value");
+  panel.maxWidth = "50%";
+  assert.equal(panel.maxWidth, "50%", "panel maxWidth is set to 50%");
+  panel.maxWidth = "";
+  assert.equal(panel.maxWidth, settings.maxWidth, "panel maxWidth returns to default on empty string");
+});


### PR DESCRIPTION
fix #11013