### PR TITLE
Add a11y tests for aria-labelledby with currency input questions Fix #11049

### DIFF
--- a/packages/survey-core/src/question_custom.ts
+++ b/packages/survey-core/src/question_custom.ts
@@ -897,14 +897,23 @@ export class QuestionCustomModel extends QuestionCustomModelBase {
   public get contentQuestion(): Question {
     return this.questionWrapper;
   }
-  public get a11y_input_ariaLabelledBy(): string {
+  public get ariaTitleId(): string {
     if (this.contentQuestion) {
-      return this.contentQuestion.a11y_input_ariaLabelledBy;
+      return this.contentQuestion.ariaTitleId;
     }
-    if (this.hasTitle && !this.parentQuestion) {
-      return this.ariaTitleId;
+    return this.id + "_ariaTitle11";
+  }
+  public get ariaDescriptionId(): string {
+    if (this.contentQuestion) {
+      return this.contentQuestion.ariaDescriptionId;
     }
-    return null;
+    return this.id + "_ariaDescription";
+  }
+  public get commentId(): string {
+    if (this.contentQuestion) {
+      return this.contentQuestion.commentId;
+    }
+    return this.id + "_comment";
   }
   protected createQuestion(): Question {
     var json = this.customQuestion.json;

--- a/packages/survey-core/tests/a11y.ts
+++ b/packages/survey-core/tests/a11y.ts
@@ -191,5 +191,7 @@ QUnit.test("a11y: aria-labelledby customquestion Bug#11049", (assert) => {
   var survey = new SurveyModel(config);
   var q1 = survey.getQuestionByName("q1");
 
-  assert.equal(q1.a11y_input_ariaLabelledBy, q1.contentQuestion.a11y_input_ariaLabelledBy);
+  assert.equal(q1.ariaTitleId, q1.contentQuestion.ariaTitleId);
+  assert.equal(q1.ariaDescriptionId, q1.contentQuestion.ariaDescriptionId);
+  assert.equal(q1.commentId, q1.contentQuestion.commentId);
 });


### PR DESCRIPTION
Fix #11049