### PR TITLE
Dynamic Matrix - A column doesn't render a unique value error on each row when a column has an Expression validator fix #11155

### DIFF
--- a/packages/survey-core/src/question_matrixdropdownbase.ts
+++ b/packages/survey-core/src/question_matrixdropdownbase.ts
@@ -544,6 +544,12 @@ export class MatrixDropdownRowModelBase extends DynamicItemModelBase implements 
       this.runTriggersOnSetValue(changedName, newColumnValue);
     }
     this.onAnyValueChanged(rowName, "");
+    if (!isComment && changedQuestion) {
+      const col = this.data.columns.filter(c => c.name === name)[0];
+      if (col && col.isUnique) {
+        this.data.checkIfValueInRowDuplicated(this, changedQuestion);
+      }
+    }
   }
 
   private onCellValueChanging(question: Question, newValue: any, isComment: boolean): any {

--- a/packages/survey-core/src/question_matrixdropdownbase.ts
+++ b/packages/survey-core/src/question_matrixdropdownbase.ts
@@ -545,9 +545,12 @@ export class MatrixDropdownRowModelBase extends DynamicItemModelBase implements 
     }
     this.onAnyValueChanged(rowName, "");
     if (!isComment && changedQuestion) {
-      const col = this.data.columns.filter(c => c.name === name)[0];
-      if (col && col.isUnique) {
-        this.data.checkIfValueInRowDuplicated(this, changedQuestion);
+      const survey = <any>this.getSurvey();
+      if (survey && survey.isValidateOnValueChanged) {
+        const col = this.data.columns.filter(c => c.name === name)[0];
+        if (col && col.isUnique) {
+          this.data.checkIfValueInRowDuplicated(this, changedQuestion);
+        }
       }
     }
   }

--- a/packages/survey-core/tests/question_matrixdynamictests.ts
+++ b/packages/survey-core/tests/question_matrixdynamictests.ts
@@ -11530,3 +11530,76 @@ QUnit.test("onMatrixCellValueChanged event should have oldValue and value in opt
   assert.equal(changedLog[5].value, "text2", "New text value is text2");
   assert.equal(changedLog[5].oldValue, "text1", "Old text value is text1");
 });
+
+QUnit.test("isUnique error should appear in second matrix with validators when duplicate values are set, bug#XXXX", function (assert) {
+  const survey = new SurveyModel({
+    pages: [
+      {
+        name: "page1",
+        elements: [
+          {
+            type: "matrixdynamic",
+            name: "matrix1",
+            columns: [
+              {
+                name: "b",
+                cellType: "text",
+                isUnique: true
+              },
+              {
+                name: "c",
+                cellType: "text"
+              }
+            ]
+          },
+          {
+            type: "matrixdynamic",
+            name: "matrix2",
+            columns: [
+              {
+                name: "b",
+                cellType: "text",
+                isUnique: true,
+                validators: [
+                  {
+                    type: "expression",
+                    text: "'{row.c} empty'",
+                    expression: "{row.c} empty"
+                  }
+                ]
+              },
+              {
+                name: "c",
+                cellType: "text"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    checkErrorsMode: "onValueChanged"
+  });
+
+  const matrix1 = <QuestionMatrixDynamicModel>survey.getQuestionByName("matrix1");
+  const matrix2 = <QuestionMatrixDynamicModel>survey.getQuestionByName("matrix2");
+  const rows1 = matrix1.visibleRows;
+  const rows2 = matrix2.visibleRows;
+
+  // Set duplicate values in matrix1
+  const cell1_row0 = rows1[0].getQuestionByColumnName("b");
+  const cell1_row1 = rows1[1].getQuestionByColumnName("b");
+  cell1_row0.value = "abc";
+  cell1_row1.value = "abc";
+
+  assert.equal(cell1_row0.errors.length, 1, "matrix1 row0 cell 'b' has unique error");
+  assert.equal(cell1_row1.errors.length, 1, "matrix1 row1 cell 'b' has unique error");
+
+  // Set duplicate values in matrix2
+  const cell2_row0 = rows2[0].getQuestionByColumnName("b");
+  const cell2_row1 = rows2[1].getQuestionByColumnName("b");
+  cell2_row0.value = "abc";
+  cell2_row1.value = "abc";
+
+  assert.equal(cell2_row0.errors.length, 1, "matrix2 row0 cell 'b' has unique error");
+  assert.equal(cell2_row1.errors.length, 1, "matrix2 row1 cell 'b' should have unique error");
+});

--- a/packages/survey-core/tests/question_matrixdynamictests.ts
+++ b/packages/survey-core/tests/question_matrixdynamictests.ts
@@ -11531,7 +11531,7 @@ QUnit.test("onMatrixCellValueChanged event should have oldValue and value in opt
   assert.equal(changedLog[5].oldValue, "text1", "Old text value is text1");
 });
 
-QUnit.test("isUnique error should appear in second matrix with validators when duplicate values are set, bug#XXXX", function (assert) {
+QUnit.test("isUnique error should appear in second matrix with validators when duplicate values are set, bug#11155", function (assert) {
   const survey = new SurveyModel({
     pages: [
       {


### PR DESCRIPTION
fix #11155