### PR TITLE
DateTime Mask - Display Format is not applied when using "defaultValueExpression": "today()" fix #11158

### DIFF
--- a/packages/survey-core/src/question_text.ts
+++ b/packages/survey-core/src/question_text.ts
@@ -505,7 +505,11 @@ export class QuestionTextModel extends QuestionTextBase {
   }
   protected convertFuncValuetoQuestionValue(val: any): any {
     let type = this.maskTypeIsEmpty ? this.inputType : this.maskSettings.getTypeForExpressions();
-    return Helpers.convertValToQuestionVal(val, type);
+    const res = Helpers.convertValToQuestionVal(val, type);
+    if (!this.maskTypeIsEmpty && this.maskSettings.saveMaskedValue && typeof res === "string") {
+      return this.maskInstance.getMaskedValue(res);
+    }
+    return res;
   }
   private getMinMaxErrorText(errorText: string, value: any): string {
     if (Helpers.isValueEmpty(value)) return errorText;

--- a/packages/survey-core/tests/mask/mask_datetime_tests.ts
+++ b/packages/survey-core/tests/mask/mask_datetime_tests.ts
@@ -1354,7 +1354,7 @@ QUnit.test("Mask datetime with defaultValue includes seconds, #10820", function 
   assert.equal(q1.inputValue, "09/04/2024 12:34:56");
 });
 
-QUnit.test("Mask datetime with defaultValueExpression today() and saveMaskedValue", function (assert) {
+QUnit.test("Mask datetime with defaultValueExpression today() and saveMaskedValue, Bug#11158", function (assert) {
   function todayMock() {
     return new Date(2025, 3, 10);
   }

--- a/packages/survey-core/tests/mask/mask_datetime_tests.ts
+++ b/packages/survey-core/tests/mask/mask_datetime_tests.ts
@@ -1353,3 +1353,28 @@ QUnit.test("Mask datetime with defaultValue includes seconds, #10820", function 
   const q1 = <QuestionTextModel>survey.getQuestionByName("q1");
   assert.equal(q1.inputValue, "09/04/2024 12:34:56");
 });
+
+QUnit.test("Mask datetime with defaultValueExpression today() and saveMaskedValue", function (assert) {
+  function todayMock() {
+    return new Date(2025, 3, 10);
+  }
+  FunctionFactory.Instance.register("todayMock", todayMock);
+  const survey = new SurveyModel({
+    elements: [
+      {
+        type: "text",
+        name: "date1",
+        defaultValueExpression: "todayMock()",
+        maskType: "datetime",
+        maskSettings: {
+          saveMaskedValue: true,
+          pattern: "dd.mm.yyyy"
+        }
+      },
+    ]
+  });
+  const q1 = <QuestionTextModel>survey.getQuestionByName("date1");
+  assert.equal(q1.inputValue, "10.04.2025", "inputValue is masked");
+  assert.equal(q1.value, "10.04.2025", "value is saved as masked");
+  FunctionFactory.Instance.unregister("todayMock");
+});


### PR DESCRIPTION
fix #11158