### PR TITLE
Add noEmitOnError option to Rollup configurations to prevent TypeScri…

### DIFF
--- a/packages/survey-core/rollup.config.mjs
+++ b/packages/survey-core/rollup.config.mjs
@@ -4,6 +4,7 @@ import { createEsmConfig, createUmdConfig, createCssConfig } from "../../rollup.
 import fs from "fs-extra";
 import process from "process";
 import pkg from "./package.json" with { type: "json" };
+import { isNotEmittedStatement } from "typescript";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const buildPath = resolve(__dirname, "build");
@@ -115,6 +116,7 @@ export default (options = {}) => {
       external: [],
       dir: resolve(buildPath, "./fesm"),
       version: pkg.version,
+      noEmitOnError: !options.watch,
     }),
     createUmdConfig({
       input: {
@@ -128,6 +130,7 @@ export default (options = {}) => {
       globalName: "Survey",
       globals: {},
       version: pkg.version,
+      noEmitOnError: !options.watch,
     }),
     createCssConfig({
       input: {

--- a/packages/survey-js-ui/rollup.config.mjs
+++ b/packages/survey-js-ui/rollup.config.mjs
@@ -111,6 +111,7 @@ export default (options = {}) => {
       },
       dir: resolve(buildPath, "./fesm"),
       version: pkg.version,
+      noEmitOnError: !options.watch,
     }),
     createUmdConfig({
       input: {
@@ -132,6 +133,7 @@ export default (options = {}) => {
         "jquery": "jQuery",
       },
       version: pkg.version,
+      noEmitOnError: !options.watch,
     })
   ];
 };

--- a/packages/survey-react-ui/rollup.config.mjs
+++ b/packages/survey-react-ui/rollup.config.mjs
@@ -94,6 +94,7 @@ export default (options = {}) => {
       ],
       dir: resolve(buildPath, "./fesm"),
       version: pkg.version,
+      noEmitOnError: !options.watch,
     }),
     createUmdConfig({
       input: {
@@ -115,6 +116,7 @@ export default (options = {}) => {
         "survey-core": "Survey"
       },
       version: pkg.version,
+      noEmitOnError: !options.watch,
     }),
   ];
 };

--- a/rollup.helpers.mjs
+++ b/rollup.helpers.mjs
@@ -94,7 +94,7 @@ function pluginIgnoreStyles() {
 
 export function createUmdConfig(options) {
 
-  const { input, globalName, external, globals, dir, tsconfig, declarationDir = null, emitMinified, exports, useEsbuild, version, emitCss, virtualModules, aliases, resolve, sourceMap = true } = options;
+  const { input, globalName, external, globals, dir, tsconfig, declarationDir = null, emitMinified, exports, useEsbuild, version, emitCss, virtualModules, aliases, resolve, sourceMap = true, noEmitOnError = true } = options;
 
   if (Object.keys(input).length > 1) throw Error("umd config accepts only one input");
 
@@ -117,6 +117,7 @@ export function createUmdConfig(options) {
       useEsbuild
         ? rollupEsbuild({ tsconfig: tsconfig, charset: "utf8", sourceMap: sourceMap })
         : typescript({
+          noEmitOnError: noEmitOnError,
           tsconfig: tsconfig,
           filterRoot: false,
           compilerOptions: {
@@ -167,7 +168,7 @@ export function createUmdConfig(options) {
 
 export function createEsmConfig(options) {
 
-  const { input, external, dir, tsconfig, sharedFileName, useEsbuild, version, emitCss, virtualModules, aliases, resolve, sourceMap = true } = options;
+  const { input, external, dir, tsconfig, sharedFileName, useEsbuild, version, emitCss, virtualModules, aliases, resolve, sourceMap = true, noEmitOnError = true } = options;
 
   return {
     context: "this",
@@ -187,6 +188,7 @@ export function createEsmConfig(options) {
       useEsbuild
         ? rollupEsbuild({ tsconfig: tsconfig, charset: "utf8", sourceMap: sourceMap })
         : typescript({
+          noEmitOnError: noEmitOnError,
           tsconfig: tsconfig,
           filterRoot: false,
           compilerOptions: {


### PR DESCRIPTION
…pt errors from being ignored.

noEmitOnError option depends on the rollup watch mode.