### PR TITLE
Adding errors in onValidatePage handler doesn't prevent validation fix #11171

### DIFF
--- a/packages/survey-core/src/survey.ts
+++ b/packages/survey-core/src/survey.ts
@@ -4383,16 +4383,31 @@ export class SurveyModel extends SurveyElementCore
       isFocusOnFirstError = this.focusOnFirstError;
     }
     if (!page) return true;
-    let callback = undefined;
+    let callback: any = undefined;
+    let syncCallbackHasErrors: boolean | undefined;
     if (onAsyncValidation) {
-      callback = (res: boolean) => { onAsyncValidation(!res); };
+      callback = (res: boolean) => {
+        if (syncCallbackHasErrors === undefined) {
+          syncCallbackHasErrors = !res;
+        } else {
+          const handlerHasErrors = this.fireValidatedErrorsOnPage(page);
+          onAsyncValidation(!res || handlerHasErrors);
+        }
+      };
     }
     const res = page.validate(true, isFocusOnFirstError, callback);
-    this.fireValidatedErrorsOnPage(page);
-    return res;
+    if (syncCallbackHasErrors === undefined && onAsyncValidation) {
+      syncCallbackHasErrors = false;
+      return res;
+    }
+    const handlerHasErrors = this.fireValidatedErrorsOnPage(page);
+    if (onAsyncValidation && syncCallbackHasErrors !== undefined) {
+      onAsyncValidation(syncCallbackHasErrors || handlerHasErrors);
+    }
+    return res && !handlerHasErrors;
   }
-  private fireValidatedErrorsOnPage(page: PageModel) {
-    if (this.onValidatePage.isEmpty || !page) return;
+  private fireValidatedErrorsOnPage(page: PageModel): boolean {
+    if (this.onValidatePage.isEmpty || !page) return false;
     const questionsOnPage = this.getNestedQuestionsByQuestionArray(page.questions, true);
     var questions = new Array<Question>();
     var errors = new Array<SurveyError>();
@@ -4405,11 +4420,13 @@ export class SurveyModel extends SurveyElementCore
         }
       }
     }
+    const errorsCountBeforeFire = errors.length;
     this.onValidatePage.fire(this, {
       questions: questions,
       errors: errors,
       page: page,
     });
+    return errors.length > errorsCountBeforeFire;
   }
   /**
    * Switches the survey to the previous page.

--- a/packages/survey-core/tests/surveytests.ts
+++ b/packages/survey-core/tests/surveytests.ts
@@ -11918,6 +11918,41 @@ QUnit.test("onValidatePage doesn't include internal question errors, Bug#9565", 
   assert.equal(questions[1].name, "minvalue", "questions[1].name");
   assert.equal(questions[2].name, "maxvalue", "questions[2].name");
 });
+QUnit.test("Adding errors in onValidatePage handler should prevent navigation, Bug#11171", function (assert) {
+  const survey = new SurveyModel({
+    pages: [
+      {
+        name: "page1",
+        elements: [
+          { type: "text", name: "q1" },
+          { type: "text", name: "q2" },
+        ],
+      },
+      {
+        name: "page2",
+        elements: [
+          { type: "text", name: "q3" },
+        ],
+      },
+    ],
+  });
+  survey.onValidatePage.add(function (sender, options) {
+    const q1Val = Number(survey.getValue("q1")) || 0;
+    const q2Val = Number(survey.getValue("q2")) || 0;
+    if (q1Val + q2Val > 100) {
+      options.errors.push(new CustomError("The total must not exceed 100"));
+      options.questions = options.page.questions;
+    }
+  });
+  survey.setValue("q1", 60);
+  survey.setValue("q2", 50);
+  assert.equal(survey.currentPageNo, 0, "Start on page 0");
+  survey.nextPage();
+  assert.equal(survey.currentPageNo, 0, "Should stay on page 0 because onValidatePage added errors");
+  survey.setValue("q2", 30);
+  survey.nextPage();
+  assert.equal(survey.currentPageNo, 1, "Should move to page 1 when total <= 100");
+});
 
 QUnit.test("survey.completedHtmlOnCondition", function (assert) {
   var survey = new SurveyModel();


### PR DESCRIPTION
fix #11171