### PR TITLE
Dynamic Panel - An empty dynamic matrix row is removed when another question value is modified fix #11192

### DIFF
--- a/packages/survey-core/src/question_paneldynamic.ts
+++ b/packages/survey-core/src/question_paneldynamic.ts
@@ -2228,10 +2228,22 @@ export class QuestionPanelDynamicModel extends Question implements IDynamicItemM
     if (this.settingPanelCountBasedOnValue) return;
     super.setQuestionValue(newValue, false);
     this.setPanelCountBasedOnValue();
-    for (var i = 0; i < this.panelsCore.length; i++) {
-      this.panelUpdateValueFromSurvey(this.panelsCore[i]);
+    // Do not force-refresh nested panel questions while a child question updates panel data.
+    // It may recreate nested dynamic questions (for example, matrixdynamic) from persisted
+    // value and drop transient UI-only state, such as an added trailing empty row.
+    if (!this.isSettingPanelItemData()) {
+      for (var i = 0; i < this.panelsCore.length; i++) {
+        this.panelUpdateValueFromSurvey(this.panelsCore[i]);
+      }
     }
     this.updateIsAnswered();
+  }
+
+  private isSettingPanelItemData(): boolean {
+    for (const key in this.isSetPanelItemData) {
+      if (this.isSetPanelItemData[key] > 0) return true;
+    }
+    return false;
   }
   public onSurveyValueChanged(newValue: any): void {
     if (newValue === undefined && this.isAllPanelsEmpty()) return;

--- a/packages/survey-core/tests/question_paneldynamic_tests.ts
+++ b/packages/survey-core/tests/question_paneldynamic_tests.ts
@@ -1994,6 +1994,58 @@ QUnit.test("PanelDynamic vs MatrixDynamic onValueChanged, bug#9130", function(as
   ], "check logs, #1");
 });
 
+QUnit.test("Dynamic Panel: preserve empty matrix row after changing another question, Issue #11192", function(assert) {
+  const survey = new SurveyModel({
+    pages: [
+      {
+        name: "page1",
+        elements: [
+          {
+            type: "paneldynamic",
+            name: "question1",
+            templateElements: [
+              {
+                type: "text",
+                name: "question2",
+              },
+              {
+                type: "matrixdynamic",
+                name: "question3",
+                columns: [
+                  {
+                    name: "Column 1",
+                    cellType: "text",
+                  }
+                ],
+                rowCount: 0,
+              },
+            ],
+          },
+        ],
+      },
+    ]
+  });
+  const panel = <QuestionPanelDynamicModel>survey.getQuestionByName("question1");
+  panel.addPanel();
+
+  const secondPanelMatrix = <QuestionMatrixDynamicModel>panel.panels[0].getQuestionByName("question3");
+  secondPanelMatrix.addRow();
+  let rows = secondPanelMatrix.visibleRows;
+  rows[0].cells[0].question.value = "a";
+  secondPanelMatrix.addRow();
+
+  assert.equal(rows.length, 2, "The matrix has 2 rows before changing another panel value");
+  assert.equal(rows[0].cells[0].question.value, "a", "The first row has value in the first column");
+  assert.deepEqual(rows[1].value, {}, "The second row is empty before changing another panel value");
+
+  panel.panels[0].getQuestionByName("question2").value = "test";
+
+  rows = secondPanelMatrix.visibleRows;
+  assert.equal(rows.length, 2, "The matrix still has 2 rows after changing another panel value");
+  assert.equal(rows[0].cells[0].question.value, "a", "The first row value is preserved");
+  assert.deepEqual(rows[1].value, {}, "The trailing empty row is preserved");
+});
+
 function updateObjsQuestions(objs: Array<any>): void {
   for (var i = 0; i < objs.length; i++) {
     objs[i].question = objs[i].question.name;


### PR DESCRIPTION
fix #11192