### PR TITLE
fix: mark preceding pages as passed on survey resume

### DIFF
--- a/packages/survey-core/src/survey.ts
+++ b/packages/survey-core/src/survey.ts
@@ -3980,6 +3980,15 @@ export class SurveyModel extends SurveyElementCore
         oldValue.passed = true;
       }
     }
+    if (newValue) {
+      const newIndex = this.visiblePages.indexOf(newValue);
+      for (let i = 0; i < newIndex; i++) {
+        const page = this.visiblePages[i];
+        if (!page.passed) {
+          page.passed = true;
+        }
+      }
+    }
     if (this.isCurrentPageRendered === true) {
       this.isCurrentPageRendered = false;
     }

--- a/packages/survey-core/tests/surveyProgressButtonsTest.ts
+++ b/packages/survey-core/tests/surveyProgressButtonsTest.ts
@@ -93,6 +93,22 @@ describe("ProgressButtons", () => {
     expect(progress.getListElementCss(1), "1) Page 2 style is empty").toBe("");
     expect(progress.getListElementCss(2), "1) Page 3 style is non clickable").toBe(survey.css.progressButtonsListElementNonClickable);
   });
+  test("ProgressButtons pages before current are marked passed on survey resume", () => {
+    const json: any = {
+      "pages": [
+        { "name": "page1", "elements": [{ "type": "text", "name": "q1" }] },
+        { "name": "page2", "elements": [{ "type": "text", "name": "q2" }] },
+        { "name": "page3", "elements": [{ "type": "text", "name": "q3" }] }
+      ]
+    };
+    const survey: SurveyModel = new SurveyModel(json);
+    survey.data = { q1: "a", q2: "b" };
+    survey.currentPageNo = 2;
+    const progress: ProgressButtons = new ProgressButtons(survey);
+    expect(progress.getListElementCss(0), "Page 1 should be passed").toBe(survey.css.progressButtonsListElementPassed);
+    expect(progress.getListElementCss(1), "Page 2 should be passed").toBe(survey.css.progressButtonsListElementPassed);
+    expect(progress.getListElementCss(2), "Page 3 should be current").toBe(survey.css.progressButtonsListElementCurrent);
+  });
   test("ProgressButtons progressText is updated on current page change", () => {
     const survey = new SurveyModel({
       pages: [


### PR DESCRIPTION
## Problem

When resuming a survey by setting `currentPageNo` to a value greater than 0,
progress bar buttons for pages before the current position were not shown as
"passed" (completed).

`currentPageChanged()` only marked the directly preceding page (`oldValue`) as
`passed = true`. Pages before the restored position were never marked,
leaving their indicators in an unvisited state.

## Fix

In `currentPageChanged()`, after marking `oldValue` as passed, loop through all
visible pages whose index is less than `newValue`'s and ensure they are also
marked as `passed = true`.

During normal sequential navigation this is a no-op (those pages are already
`passed`). The change only takes effect when jumping — most notably during
survey resume.

## Verification

- Added a unit test in `surveyProgressButtonsTest.ts` covering the resume scenario
- All 4326 existing unit tests pass (`vitest run`)
- Manually verified in the browser with `progressBarType: "buttons"` and `currentPageNo = 2`