### PR TITLE
getDefaultPropertyValue returns undefined for localizable properties …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ packages/survey-react-ui/tests/bundle/*
 packages/survey-js-ui/tests/bundle/*
 packages/survey-core/test_output.txt
 .claude/
+packages/survey-core/promts/

--- a/packages/survey-core/src/base.ts
+++ b/packages/survey-core/src/base.ts
@@ -723,8 +723,15 @@ export class Base implements IObjectValueContext {
     if (!!prop.defaultValueFunc) return prop.defaultValueFunc(this);
     const dValue = prop.getDefaultValue(this);
     if (!this.isValueUndefined(dValue) && !Array.isArray(dValue)) return dValue;
-    const locStr = this.localizableStrings ? this.localizableStrings[name] : undefined;
-    if (locStr && locStr.localizationName) return this.getLocalizationString(locStr.localizationName);
+    let locStr = this.localizableStrings ? this.localizableStrings[name] : undefined;
+    if (!locStr && prop.isLocalizable && !!prop.serializationProperty) {
+      //localizable strings declared via the property decorator are created on the first access
+      locStr = (<any>this)[prop.serializationProperty];
+    }
+    if (locStr && locStr.localizationName) {
+      const defaultStr = this.getLocalizationString(locStr.localizationName);
+      if (!!defaultStr) return defaultStr;
+    }
     if (prop.type == "boolean" || prop.type == "switch") return false;
     if (prop.isCustom && !!prop.onGetValue) return prop.onGetValue(this);
     return undefined;

--- a/packages/survey-core/tests/basetests.ts
+++ b/packages/survey-core/tests/basetests.ts
@@ -8,6 +8,7 @@ import { SurveyModel } from "../src/survey";
 import { Action } from "../src/actions/action";
 import { findParentByClassNames } from "../src/utils/dom-utils";
 import { QuestionDropdownModel } from "../src/question_dropdown";
+import { QuestionTextModel } from "../src/question_text";
 import { settings } from "../src/settings";
 import { describe, test, expect, vi } from "vitest";
 export * from "../src/localization/german";
@@ -825,6 +826,17 @@ describe("Base", () => {
     expect(question.placeholder, "placeholder property value is empty string").toBe("");
     question.resetPropertyValue("placeholder");
     expect(question.placeholder, "placeholder property value is reset, #2").toBe("Select...");
+  });
+  test("base.hasDefaultPropertyValue for a lazily created localizable property, minErrorText, Bug#11431", () => {
+    const question = new QuestionTextModel("q1");
+    question.inputType = "number";
+    expect(question.hasDefaultPropertyValue("minErrorText"), "minErrorText has a default value before the first access").toBe(true);
+    expect(question.getDefaultPropertyValue("minErrorText"), "minErrorText default value").toBe("The value should not be less than {0}");
+
+    const item = new ItemValue("item1");
+    expect(item.hasDefaultPropertyValue("text"), "itemvalue.text has no default value, the 'text' localization string is empty").toBe(false);
+    expect(item.locText.renderedHtml, "itemvalue.locText is rendered as the value").toBe("item1");
+    expect(item.hasDefaultPropertyValue("text"), "itemvalue.text has no default value after locText is created").toBe(false);
   });
   test("base.resetPropertyValue() for localization string", () => {
     const survey = new SurveyModel();


### PR DESCRIPTION
…declared via the property decorator until the string is first accessed

 fix #11431