### PR TITLE
fix(mask): use plain text from paste event for masked inputs

### DIFF
--- a/packages/survey-core/src/mask/input_element_adapter.ts
+++ b/packages/survey-core/src/mask/input_element_adapter.ts
@@ -4,6 +4,7 @@ import { ITextInputParams } from "./mask_utils";
 export class InputElementAdapter {
   private prevUnmaskedValue: string = undefined;
   private maskedEmptyValue : string;
+  private pastedPlainText: string | undefined = undefined;
 
   private setInputValue(value: string) {
     if (this.inputElement.maxLength >= 0 && this.inputElement.maxLength < value.length) {
@@ -54,6 +55,17 @@ export class InputElementAdapter {
     this.updateInputValue();
   };
 
+  pasteHandler = (event: ClipboardEvent) => {
+    if (this.inputElement.readOnly) {
+      event.preventDefault();
+      return;
+    }
+    const plainText = event.clipboardData?.getData("text/plain");
+    if (plainText !== undefined && plainText !== null) {
+      this.pastedPlainText = plainText;
+    }
+  };
+
   beforeInputHandler = (event: any) => {
     if (this.inputElement.readOnly) {
       event.preventDefault();
@@ -92,11 +104,16 @@ export class InputElementAdapter {
     if (event.inputType === "deleteContentForward" && args.selectionStart === args.selectionEnd) {
       args.selectionEnd += 1;
     }
+    if (event.inputType === "insertFromPaste" && this.pastedPlainText !== undefined) {
+      args.insertedChars = this.pastedPlainText;
+      this.pastedPlainText = undefined;
+    }
 
     return args;
   }
   public addInputEventListener(): void {
     if (!!this.inputElement) {
+      this.inputElement.addEventListener("paste", this.pasteHandler);
       this.inputElement.addEventListener("beforeinput", this.beforeInputHandler);
       this.inputElement.addEventListener("click", this.clickHandler);
       this.inputElement.addEventListener("focus", this.focusHandler);
@@ -106,6 +123,7 @@ export class InputElementAdapter {
   }
   public removeInputEventListener(): void {
     if (!!this.inputElement) {
+      this.inputElement.removeEventListener("paste", this.pasteHandler);
       this.inputElement.removeEventListener("beforeinput", this.beforeInputHandler);
       this.inputElement.removeEventListener("click", this.clickHandler);
       this.inputElement.removeEventListener("focus", this.focusHandler);

--- a/packages/survey-core/tests/mask/input_mask_tests.ts
+++ b/packages/survey-core/tests/mask/input_mask_tests.ts
@@ -239,4 +239,35 @@ describe("Input mask", () => {
 
     testInput.remove();
   });
+
+  test("InputElementAdapter insertFromPaste uses text/plain when beforeinput supplies HTML", () => {
+    const testInput = document.createElement("input");
+    const inputMaskPattern = new InputMaskPattern();
+    inputMaskPattern.pattern = "+1(999) 999-9999";
+    const adapter = new InputElementAdapter(inputMaskPattern, testInput);
+    testInput.value = "+1(___) ___-____";
+    testInput.selectionStart = 0;
+    testInput.selectionEnd = 0;
+
+    const plainText = "(123) 456-7890";
+    const htmlClipboard = "<meta charset='utf-8'><span style=\"color: rgba(0, 0, 0, 0.91); font-size: 16px;\">(123) 456-7890</span>";
+
+    const pasteEvent = new Event("paste", { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(pasteEvent, "clipboardData", {
+      value: {
+        getData: (type: string) => type === "text/plain" ? plainText : htmlClipboard
+      }
+    });
+    testInput.dispatchEvent(pasteEvent);
+
+    adapter.beforeInputHandler({
+      data: htmlClipboard,
+      inputType: "insertFromPaste",
+      target: testInput,
+      preventDefault: () => {}
+    });
+    expect(testInput.value).toBe("+1(123) 456-7890");
+
+    testInput.remove();
+  });
 });


### PR DESCRIPTION
Some browsers supply HTML clipboard content via beforeinput event.data when pasting into an input, which causes pattern masks to extract digits from markup instead of the copied phone number. Read text/plain from the paste event and prefer it over beforeinput data for insertFromPaste.