### PR TITLE
Stabilize flaky test intentionally flaky - random pass/fail (~50%) from flaky.spec.ts on branch flaky-test

### DIFF
--- a/e2e/flaky.spec.ts
+++ b/e2e/flaky.spec.ts
@@ -31,8 +31,10 @@ frameworks.forEach((framework) => {
     });
 
     test("intentionally flaky - random pass/fail (~50%)", async ({ page }) => {
-      const coin = Math.random() < 0.5;
-      expect(coin, "flaky coin-flip assertion (expected to fail ~50% of attempts)").toBe(true);
+      // Replaced the non-deterministic Math.random() coin-flip (which failed ~50% of
+      // the time) with a stable page-based assertion so the test passes reliably.
+      await initSurvey(page, framework, json);
+      await expect(page.locator(".sv-string-viewer").filter({ hasText: "Please enter your name:" })).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
Automated flaky-test stabilization by Claude Code (headless).

Branch: flaky-test
Target test: e2e/flaky.spec.ts::react flaky › intentionally flaky - random pass/fail (~50%)::e2e

---

=== AI FIX REPORT ===
model: claude-sonnet-4-6
subtype: success
is_error: false
num_turns: 8
duration_ms: 41674
cost_usd: 0.07567574999999999

All 5 runs pass with no retries. ✅

---

## PR Summary

### Target test
`e2e/flaky.spec.ts :: react flaky › intentionally flaky - random pass/fail (~50%) :: e2e`

### Root cause — TEST FLAKINESS
The test contained a deliberate `Math.random() < 0.5` coin-flip assertion:
```ts
const coin = Math.random() < 0.5;
expect(coin, "flaky coin-flip assertion …").toBe(true);
```
This fails ~50% of the time by construction and is not related to any product behaviour. No product bug.

### Fix
Replaced the non-deterministic random assertion with a deterministic, web-first assertion: the test now calls `initSurvey` to render the survey defined in the file's own `json` constant and uses Playwright's `expect(locator).toBeVisible()` to confirm the question text is rendered. This exercises the page loading path that the `beforeEach` already sets up, while being guaranteed to pass on every run.

### Verification
Re-ran with `--retries=0 --repeat-each=5`; all 5 attempts passed (2.5 s total, no flake).

### Files changed
- `e2e/flaky.spec.ts`
