### PR TITLE
Stabilize flaky test check auto next page with keyboard from autoNextPage.spec.ts on branch flaky-test

### DIFF
--- a/e2e/survey/autoNextPage.spec.ts
+++ b/e2e/survey/autoNextPage.spec.ts
@@ -130,22 +130,23 @@ frameworks.forEach((framework) => {
       await initSurvey(page, framework, json);
 
       const progressText = page.locator(".sd-progress-buttons__page-title");
-      let text = "Page 1 of 3";
-      expect(await progressText.textContent()).toBe(text);
+      const firstRadio = page.locator("input[type='radio']").first();
+      await expect(progressText).toHaveText("Page 1 of 3");
+      await expect(firstRadio).toBeFocused();
 
       await page.keyboard.press("ArrowDown");
       await page.keyboard.press("Tab");
       await page.keyboard.press("Enter");
 
-      text = "Page 2 of 3";
-      expect(await progressText.textContent()).toBe(text);
+      await expect(progressText).toHaveText("Page 2 of 3");
+      await expect(firstRadio).toBeFocused();
       await page.keyboard.press("ArrowDown");
       await page.keyboard.press("Tab");
       await page.keyboard.press("Tab");
       await page.keyboard.press("Enter");
 
-      text = "Page 3 of 3";
-      expect(await progressText.textContent()).toBe(text);
+      await expect(progressText).toHaveText("Page 3 of 3");
+      await expect(firstRadio).toBeFocused();
       await page.keyboard.press("ArrowDown");
       await page.keyboard.press("Tab");
       await page.keyboard.press("Tab");


### PR DESCRIPTION
Automated flaky-test stabilization by Claude Code (headless).

Branch: flaky-test
Target test: e2e/survey/autoNextPage.spec.ts::react autoNextPage › check auto next page with keyboard::e2e

---

=== AI FIX REPORT ===
model: claude-sonnet-4-6
subtype: success
is_error: false
num_turns: 31
duration_ms: 564794
cost_usd: 1.1552223000000001

10/10 — rock solid. Here's the PR summary:

---

## PR Summary

### Target test
`e2e/survey/autoNextPage.spec.ts :: react autoNextPage › check auto next page with keyboard :: e2e`

### Root cause — Test Flakiness (timing race)

**Two compounding races:**

1. **Bare synchronous assertions** — the original test used `expect(await progressText.textContent()).toBe(text)` which reads the DOM exactly once. After keyboard-driven page navigation the progress text update is asynchronous, so the assertion could fire before the new page's text had landed, yielding `"Page 2 of 3"` when `"Page 3 of 3"` was expected.

2. **`autoFocusFirstQuestion` fires inside a `setTimeout(..., 1)`** — In `survey.ts`, `afterRenderPage` schedules `scrollToTopOnPageChange` (which calls `page.focusFirstQuestion()`) with a 1 ms delay. Playwright's `toHaveText()` polling passes as soon as the React render commits the new progress text, but the 1 ms timer may not have fired yet. When the test immediately presses `ArrowDown`, no radio input is focused, so the key does nothing, and the subsequent `Tab → Tab → Enter` lands on unexpected elements instead of the Next button — leaving the survey stuck on page 2.

### Fix

* Replaced all bare `expect(await progressText.textContent()).toBe(text)` calls with Playwright web-first assertions `await expect(progressText).toHaveText(text)` (auto-retries).
* After each page-transition assertion, added `await expect(firstRadio).toBeFocused()` — this waits for the 1 ms `autoFocusFirstQuestion` timer to fire and focus the first `<input type="radio">` before the next `ArrowDown` is sent, eliminating the race.

### Files changed
- `e2e/survey/autoNextPage.spec.ts`
