### PR TITLE
Stabilize flaky test 'check auto next page with keyboard' from 'autoNextPage.spec.ts' on branch 'flaky-test'

### DIFF
--- a/e2e/survey/autoNextPage.spec.ts
+++ b/e2e/survey/autoNextPage.spec.ts
@@ -138,14 +138,22 @@ frameworks.forEach((framework) => {
       await page.keyboard.press("Enter");
 
       text = "Page 2 of 3";
-      expect(await progressText.textContent()).toBe(text);
+      await expect(progressText).toHaveText(text);
+      await page.waitForFunction(() => {
+        const el = document.activeElement as HTMLInputElement;
+        return el && el.type === "radio";
+      });
       await page.keyboard.press("ArrowDown");
       await page.keyboard.press("Tab");
       await page.keyboard.press("Tab");
       await page.keyboard.press("Enter");
 
       text = "Page 3 of 3";
-      expect(await progressText.textContent()).toBe(text);
+      await expect(progressText).toHaveText(text);
+      await page.waitForFunction(() => {
+        const el = document.activeElement as HTMLInputElement;
+        return el && el.type === "radio";
+      });
       await page.keyboard.press("ArrowDown");
       await page.keyboard.press("Tab");
       await page.keyboard.press("Tab");


### PR DESCRIPTION
Automated flaky-test stabilization by Claude Code (headless).

Branch: flaky-test
Target test: e2e/survey/autoNextPage.spec.ts::react autoNextPage › check auto next page with keyboard::e2e

---

=== AI FIX REPORT ===
model: claude-sonnet-4-6
subtype: success
is_error: false
num_turns: 50
duration_ms: 576028
cost_usd: 1.4003766

All 6 tests in the file pass. The fix is complete.

---

## Summary

### Root cause (Test Flakiness — timing race)

**File changed:** `e2e/survey/autoNextPage.spec.ts`

**What was flaky and why:**

The test `check auto next page with keyboard` had two races:

1. **No-retry assertions after page transitions** — The original code used `expect(await progressText.textContent()).toBe(text)` immediately after pressing `Enter` to navigate pages. This evaluates once without retrying, so if the page-transition React re-render hadn't completed yet, it would read stale text and fail.

2. **Focus not yet set before keyboard input** — In `survey.ts`, `afterRenderPage` schedules `focusFirstQuestion()` with `setTimeout(fn, 1)`. This means focus on the new page's first radio input is set *asynchronously*, one JS event-loop tick after the DOM update. Playwright could see `"Page 2 of 3"` in the DOM and immediately send `ArrowDown`, arriving before the `setTimeout` fired — so the radio group had no focus and the key was ignored, leaving the survey stuck on Page 2 despite the 5-second `toHaveText` timeout.

**Fix applied:**

1. Replaced `expect(await progressText.textContent()).toBe(text)` (one-shot) with `await expect(progressText).toHaveText(text)` (auto-retrying web-first assertion) for post-navigation checks (Page 2 and Page 3).

2. Added `await page.waitForFunction(() => { const el = document.activeElement as HTMLInputElement; return el && el.type === "radio"; })` after each page-transition check, before the next `ArrowDown`. This waits for `autoFocusFirstQuestion`'s async `setTimeout(fn, 1)` to complete and the radio to actually receive focus before keyboard events are sent.
