### PR TITLE
Validation errors are not announced to screen readers until focus mov…

### DIFF
--- a/accessibilityTests/errors.spec.ts
+++ b/accessibilityTests/errors.spec.ts
@@ -1,0 +1,34 @@
+import { frameworks, url, initSurvey } from "./helper";
+import { test, expect } from "@playwright/test";
+const title = "errors";
+
+const json = {
+  "elements": [
+    {
+      "type": "text",
+      "name": "q1",
+      "title": "First Name",
+      "isRequired": true
+    }
+  ]
+};
+
+frameworks.forEach((framework) => {
+  test.describe(`${framework} a11y:${title}`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`${url}${framework}`);
+    });
+    // The error container must be a live region so that a validation error is
+    // announced by assistive technology even when focus is on another field
+    // (WCAG 2.1 Success Criterion 4.1.3).
+    test("error container is a live region", async ({ page }) => {
+      await initSurvey(page, framework, json);
+      await page.evaluate(() => { (window as any).survey.validate(true); });
+      const errbox = page.locator("[id$=\"_errors\"]");
+      await expect(errbox).toBeVisible();
+      await expect(errbox).toHaveAttribute("role", "alert");
+      await expect(errbox).toHaveAttribute("aria-live", "polite");
+      await expect(errbox).toHaveAttribute("aria-atomic", "true");
+    });
+  });
+});

--- a/packages/survey-angular-ui/src/errors.component.ts
+++ b/packages/survey-angular-ui/src/errors.component.ts
@@ -3,7 +3,12 @@ import { SurveyElement } from "survey-core";
 
 @Component({
   templateUrl: "./errors.component.html",
-  selector: "'[sv-ng-errors]'"
+  selector: "'[sv-ng-errors]'",
+  host: {
+    "role": "alert",
+    "aria-live": "polite",
+    "aria-atomic": "true"
+  }
 })
 export class ErrorsComponent {
   @Input() element!: SurveyElement | any;

--- a/packages/survey-react-ui/src/reactquestion.tsx
+++ b/packages/survey-react-ui/src/reactquestion.tsx
@@ -275,6 +275,9 @@ export class SurveyElementErrors extends ReactSurveyElement {
       <div
         className={this.element.cssError}
         id={this.id}
+        role="alert"
+        aria-live="polite"
+        aria-atomic="true"
       >
         {errors}
       </div>

--- a/packages/survey-vue3-ui/src/Errors.vue
+++ b/packages/survey-vue3-ui/src/Errors.vue
@@ -3,6 +3,9 @@
     v-if="element.hasVisibleErrors"
     :class="element.cssError"
     :id="element.id + '_errors'"
+    role="alert"
+    aria-live="polite"
+    aria-atomic="true"
     ref="root"
   >
     <SvComponent

--- a/tests/markup/snapshots/matrixdropdown-cell-errors-bottom.snap.html
+++ b/tests/markup/snapshots/matrixdropdown-cell-errors-bottom.snap.html
@@ -26,7 +26,7 @@
 				<td class="sd-table__cell sd-table__cell--empty sd-table__cell--error" colspan="1" title="">
 				</td>
 				<td class="sd-table__cell sd-table__cell--error sd-table__cell--error-bottom" colspan="1" title="">
-					<div class="sd-element__erbox sd-error sd-question__erbox sd-question__erbox--below-question" id="testid0row0cell1_errors">
+					<div aria-atomic="true" aria-live="polite" class="sd-element__erbox sd-error sd-question__erbox sd-question__erbox--below-question" id="testid0row0cell1_errors" role="alert">
 						<div>
 							<span aria-hidden="true">
 							</span>

--- a/tests/markup/snapshots/matrixdropdown-cell-errors-top.snap.html
+++ b/tests/markup/snapshots/matrixdropdown-cell-errors-top.snap.html
@@ -16,7 +16,7 @@
 				<td class="sd-table__cell sd-table__cell--empty sd-table__cell--error" colspan="1" title="">
 				</td>
 				<td class="sd-table__cell sd-table__cell--error sd-table__cell--error-top" colspan="1" title="">
-					<div class="sd-element__erbox sd-element__erbox--above-element sd-error sd-question__erbox sd-question__erbox--above-question" id="testid0row1cell1_errors">
+					<div aria-atomic="true" aria-live="polite" class="sd-element__erbox sd-element__erbox--above-element sd-error sd-question__erbox sd-question__erbox--above-question" id="testid0row1cell1_errors" role="alert">
 						<div>
 							<span aria-hidden="true">
 							</span>

--- a/tests/markup/snapshots/multipletext-error-bottom-v2.snap.html
+++ b/tests/markup/snapshots/multipletext-error-bottom-v2.snap.html
@@ -16,7 +16,7 @@
 		</tr>
 		<tr class="sd-multipletext__row">
 			<td class="sd-multipletext__cell sd-multipletext__cell--error sd-multipletext__cell--error-bottom">
-				<div class="sd-element__erbox sd-error sd-question__erbox sd-question__erbox--below-question">
+				<div aria-atomic="true" aria-live="polite" class="sd-element__erbox sd-error sd-question__erbox sd-question__erbox--below-question" role="alert">
 					<div>
 						<span aria-hidden="true">
 						</span>

--- a/tests/markup/snapshots/multipletext-error-top-v2.snap.html
+++ b/tests/markup/snapshots/multipletext-error-top-v2.snap.html
@@ -2,7 +2,7 @@
 	<tbody>
 		<tr class="sd-multipletext__row">
 			<td class="sd-multipletext__cell sd-multipletext__cell--error sd-multipletext__cell--error-top">
-				<div class="sd-element__erbox sd-element__erbox--above-element sd-error sd-question__erbox sd-question__erbox--above-question">
+				<div aria-atomic="true" aria-live="polite" class="sd-element__erbox sd-element__erbox--above-element sd-error sd-question__erbox sd-question__erbox--above-question" role="alert">
 					<div>
 						<span aria-hidden="true">
 						</span>

--- a/tests/markup/snapshots/question-errors-v2-bottom.snap.html
+++ b/tests/markup/snapshots/question-errors-v2-bottom.snap.html
@@ -12,7 +12,7 @@
 		<div class="sd-question__content sd-text__content" role="presentation">
 			<input aria-describedby="testid0_errors" aria-invalid="true" aria-labelledby="testid0_ariaTitle" aria-required="true" class="sd-input sd-input--error sd-text" id="testid0i" placeholder="" type="text">
 		</div>
-		<div class="sd-element__erbox sd-error sd-question__erbox sd-question__erbox--below-question" id="testid0_errors">
+		<div aria-atomic="true" aria-live="polite" class="sd-element__erbox sd-error sd-question__erbox sd-question__erbox--below-question" id="testid0_errors" role="alert">
 			<div>
 				<span aria-hidden="true">
 				</span>

--- a/tests/markup/snapshots/question-errors-v2-top.snap.html
+++ b/tests/markup/snapshots/question-errors-v2-top.snap.html
@@ -1,6 +1,6 @@
 <div style="flex:1 1 100%; max-width:100%; min-width:min(100%, 300px);">
 	<div class="sd-element sd-element--with-frame sd-question sd-question--error sd-question--error-top sd-question--title-top sd-row__question sd-row__question--small" data-name="name" id="testid0">
-		<div class="sd-element__erbox sd-element__erbox--above-element sd-error sd-question__erbox sd-question__erbox--above-question" id="testid0_errors">
+		<div aria-atomic="true" aria-live="polite" class="sd-element__erbox sd-element__erbox--above-element sd-error sd-question__erbox sd-question__erbox--above-question" id="testid0_errors" role="alert">
 			<div>
 				<span aria-hidden="true">
 				</span>


### PR DESCRIPTION
…es to the target problematic field (WCAG 2.1 Success Criterion 4.1.3)  #11523

https://github.com/surveyjs/survey-library/issues/11523