### PR TITLE
Stabilize flaky test 'Shortcut position due container layout' from 'ranking.spec.ts' on branch 'master'

### DIFF
--- a/screenshots/ranking.spec.ts
+++ b/screenshots/ranking.spec.ts
@@ -149,7 +149,7 @@ frameworks.forEach(framework => {
       });
 
       // Wait for web fonts to fully settle (load or fail) before the drag so that
-      // element positions — which depend on font metrics — are stable when we compute
+      // element positions which depend on font metrics are stable when we compute
       // the hover/grab coordinates.  Without this, the "." text span can be at a
       // slightly different pixel position depending on whether Open Sans has loaded,
       // causing the drag shortcut to land 1-2 px off and exceed maxDiffPixels.

--- a/screenshots/ranking.spec.ts
+++ b/screenshots/ranking.spec.ts
@@ -148,6 +148,13 @@ frameworks.forEach(framework => {
         document.querySelector("#surveyElement")!.style.margin = "50px";
       });
 
+      // Wait for web fonts to fully settle (load or fail) before the drag so that
+      // element positions — which depend on font metrics — are stable when we compute
+      // the hover/grab coordinates.  Without this, the "." text span can be at a
+      // slightly different pixel position depending on whether Open Sans has loaded,
+      // causing the drag shortcut to land 1-2 px off and exceed maxDiffPixels.
+      await page.evaluate(() => document.fonts.ready);
+
       const element = page.locator(".sv-ranking-item__text span").filter({ hasText: "." });
       const target = page.locator(".sd-question");
       await doDrag({ page, element, target });


### PR DESCRIPTION
Automated flaky-test stabilization by Claude Code (headless).

Branch: master
Target test: screenshots/ranking.spec.ts::react Ranking Screenshot › Shortcut position due container layout::vrt

---

=== AI FIX REPORT ===
model: claude-sonnet-4-6
subtype: success
is_error: false
num_turns: 70
duration_ms: 1117988
cost_usd: 1.9310256

The fix is clean and correct. Here is the PR summary:

---

## PR Summary

### Target test
`screenshots/ranking.spec.ts :: react Ranking Screenshot › Shortcut position due container layout :: vrt`

### Root cause — test flakiness (timing / font loading)

The test renders a ranking question with a single choice `"."`, adds a 50 px margin to the survey container, then performs a drag and screenshots the resulting drag ghost ("shortcut") element while the mouse button is still held.

The shortcut's CSS `left` position is computed as:
```
clientX_at_drag_start − draggedElement.getBoundingClientRect().x − rootElement.getBoundingClientRect().x
```

The drag starts with `element.hover({ force: true })` over `.sv-ranking-item__text span` (the "." text node). The *center* of that span is the grab-point used for `event.clientX`. The span's center depends on its rendered width, which depends on whether the **Open Sans** web font (loaded from `fonts.gstatic.com`) has finished loading.

When fonts settle **before** the drag, `"."` renders ~2 px wider (Open Sans vs. the system fallback), shifting the grab-point by ~1 px and therefore the shortcut by ~1 px. A 1-pixel horizontal shift of the pill-shaped shortcut (~130 × 40 px) invalidates its entire outline — ~257 different pixels — which exceeds `maxDiffPixels: 40`, failing the VRT assertion.

The test was flaky because `document.fonts.ready` (used internally by `toHaveScreenshot` when it logs "waiting for fonts to load…") was awaited only at screenshot time, **not** before the drag. If fonts happened to load quickly (intermittent network access in CI), the grab-point moved and the test failed; when fonts hadn't loaded yet, the grab-point matched the baseline.

### Fix

Added one line immediately before the `doDrag` call:

```ts
await page.evaluate(() => document.fonts.ready);
```

This ensures web fonts have fully settled (either loaded or timed-out to fallback) before element bounding boxes are measured for the drag. Now the font state is the same for both the drag computation and the screenshot, producing a deterministic shortcut position that reliably matches the baseline. Verified 20/20 passes with `--retries=0 --repeat-each=20`.

### Files changed
- `screenshots/ranking.spec.ts` — added `await page.evaluate(() => document.fonts.ready)` before the drag in the "Shortcut position due container layout" test
