### PR TITLE
Guard window event-listener helpers when window lacks addEventListener

### DIFF
--- a/packages/survey-core/src/dragdrop/dom-adapter.ts
+++ b/packages/survey-core/src/dragdrop/dom-adapter.ts
@@ -6,20 +6,18 @@ import { DomDocumentHelper, DomWindowHelper } from "../global_variables_utils";
 
 // WebKit requires cancelable `touchmove` events to be added as early as possible
 // see https://bugs.webkit.org/show_bug.cgi?id=184250
-if (DomWindowHelper.getWindow()) {
-  DomWindowHelper.getWindow().addEventListener(
-    "touchmove",
-    (event) => {
-      if (!DragDropDOMAdapter.PreventScrolling) {
-        return;
-      }
+DomWindowHelper.addEventListener(
+  "touchmove",
+  (event) => {
+    if (!DragDropDOMAdapter.PreventScrolling) {
+      return;
+    }
 
-      // Prevent scrolling
-      event.preventDefault();
-    },
-    { passive: false }
-  );
-}
+    // Prevent scrolling
+    event.preventDefault();
+  },
+  { passive: false }
+);
 
 export interface IDragDropDOMAdapter {
   startDrag(event: PointerEvent, draggedElement: any, parentElement: any, draggedElementNode: HTMLElement, preventSaveTargetNode: boolean): void;

--- a/packages/survey-core/src/global_variables_utils.ts
+++ b/packages/survey-core/src/global_variables_utils.ts
@@ -45,13 +45,13 @@ export class DomWindowHelper {
       return window.requestAnimationFrame(callback);
     }
   }
-  public static addEventListener(type: string, listener: (e?: any) => void): void {
-    if (!DomWindowHelper.isAvailable()) return;
-    window.addEventListener(type, listener);
+  public static addEventListener(type: string, listener: (e?: any) => void, options?: boolean | AddEventListenerOptions): void {
+    if (!DomWindowHelper.isAvailable() || typeof window.addEventListener !== "function") return;
+    window.addEventListener(type, listener, options);
   }
-  public static removeEventListener(type: string, listener: (e?: any) => void): void {
-    if (!DomWindowHelper.isAvailable()) return;
-    window.removeEventListener(type, listener);
+  public static removeEventListener(type: string, listener: (e?: any) => void, options?: boolean | EventListenerOptions): void {
+    if (!DomWindowHelper.isAvailable() || typeof window.removeEventListener !== "function") return;
+    window.removeEventListener(type, listener, options);
   }
 
   public static matchMedia(mediaQueryString: string): {matches:boolean} | null {


### PR DESCRIPTION
## Title
Guard window event-listener helpers when window lacks addEventListener

## Description

Fixes #11573

`DomWindowHelper.addEventListener`/`removeEventListener` (in `packages/survey-core/src/global_variables_utils.ts`) guard only on `typeof window !== "undefined"`. Environments like React Native define a global `window` that has no `addEventListener`/`removeEventListener` methods, so that guard passes and the call throws — most visibly through the drag-and-drop module's `touchmove` listener, which is registered at **module load time** and previously bypassed the helper entirely (`DomWindowHelper.getWindow().addEventListener(...)`), so it crashed even purely headless (no-UI) usage of `survey-core` in React Native. Repro and details in #11573.

### Change

- `global_variables_utils.ts`: `DomWindowHelper.addEventListener`/`removeEventListener` now also check `typeof window.addEventListener === "function"` (resp. `removeEventListener`) before calling it, and accept an optional `options` parameter (`AddEventListenerOptions` / `EventListenerOptions`) forwarded to the underlying call. This is additive — existing call sites that don't pass `options` are unaffected.
- `dragdrop/dom-adapter.ts`: the module-load-time `touchmove` listener registration now goes through `DomWindowHelper.addEventListener(...)` (with `{ passive: false }` passed as `options`) instead of the raw `DomWindowHelper.getWindow().addEventListener(...)` call, so it benefits from the strengthened guard.

Behavior is unchanged everywhere `window.addEventListener` is actually available (verified: same event type and options are passed through). Where it's not available, the previous behavior was an uncaught `TypeError` at import time; the new behavior is a silent no-op, consistent with how every other `DomWindowHelper` method in this file already degrades when `window`/its members aren't available (e.g. `getSelection`, `requestAnimationFrame`, `matchMedia`).

### Testing

- Added/ran the framework-free repro from the issue against a fresh build: `global.window = {}; require('survey-core')` — no longer throws; a headless `Model` can still be constructed and read/written.
- Verified (via a `window` stub with `addEventListener` present) that the `touchmove` listener still registers with the same event type and `{ passive: false }` options as before — no behavior change for browsers/WebViews.
- `npm run build` — clean.
- `npx vitest run tests/dragdropcoretests.ts tests/dragDropMatrixTests.ts tests/dragdrophelpertests.ts` — 29/29 passing.
- `npx vitest run tests/surveytests.ts` (references `DomWindowHelper`) — 733/733 passing.
- `npx eslint src/global_variables_utils.ts src/dragdrop/dom-adapter.ts --max-warnings=0` — clean.
