### PR TITLE
Fix text value updates when only whitespace changes fix #11581

### DIFF
--- a/packages/survey-core/src/question_text.ts
+++ b/packages/survey-core/src/question_text.ts
@@ -361,7 +361,7 @@ export class QuestionTextModel extends QuestionTextBase {
       }
     }
     this._inputValue = _inputValue;
-    if (!Helpers.isTwoValueEquals(this.value, value, false, true)) {
+    if (!Helpers.isTwoValueEquals(this.value, value, false, true, false)) {
       this.value = value;
     }
   }

--- a/packages/survey-core/tests/question_texttests.ts
+++ b/packages/survey-core/tests/question_texttests.ts
@@ -893,6 +893,19 @@ describe("question text tests", () => {
     const json = q1.toJSON();
     expect(json.dataList, "dataList is stored in the JSON").toEqual(["item1", "item2"]);
   });
+  test("Update question value when leading or trailing whitespace changes, #11581", () => {
+    const question = new QuestionTextModel("q1");
+
+    question.value = "Test ";
+    question.inputValue = "Test";
+    expect(question.value).toBe("Test");
+
+    question.inputValue = " Test";
+    expect(question.value).toBe(" Test");
+
+    question.inputValue = " Test ";
+    expect(question.value).toBe(" Test ");
+  });
 
   test("Numeric input validation - prevent 'e' character", () => {
     const q = new QuestionTextModel("q1");


### PR DESCRIPTION
This pull request improves how the `QuestionTextModel` handles value updates when leading or trailing whitespace changes, ensuring that such changes are properly detected and reflected. 