### PR TITLE
Stabilize flaky test 'Mobile mode: input font-size less 16px' from 'themes.spec.ts' on branch 'master'

### DIFF
--- a/screenshots/themes.spec.ts
+++ b/screenshots/themes.spec.ts
@@ -1,14 +1,14 @@
-import { test } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { frameworks, url, initSurvey, compareScreenshot } from "../e2e/helper";
 
 const title = "Survey themes Screenshot";
 
 frameworks.forEach(framework => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto(`${url}${framework}`);
-  });
-
   test.describe(`${framework} ${title}`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`${url}${framework}`);
+    });
+
     test("Check question title font size", async ({ page }) => {
       await page.setViewportSize({ width: 800, height: 1600 });
       await initSurvey(page, framework, {
@@ -441,12 +441,13 @@ frameworks.forEach(framework => {
           }
         });
       }, jsonWithInputs);
-      await page.waitForTimeout(500);
+      // Wait for React to finish re-rendering all 10 questions after fromJSON
+      await expect(page.locator(".sd-question").nth(9)).toBeVisible();
       await compareScreenshot(page, ".sd-root-modern", "survey-theme-mobile-input-size.png");
 
       await page.setViewportSize({ width: 400, height: 1000 });
-      await page.waitForTimeout(500);
       const tagboxDropdownButton = page.locator(".sd-editor-chevron-button").first();
+      await expect(tagboxDropdownButton).toBeVisible();
       await tagboxDropdownButton.scrollIntoViewIfNeeded();
       await tagboxDropdownButton.click();
       await compareScreenshot(page, ".sv-popup__container .sv-popup__content", "survey-theme-mobile-popup-input-size.png");


### PR DESCRIPTION
Automated flaky-test stabilization by Claude Code (headless).

Branch: master
Target test: screenshots/themes.spec.ts::react Survey themes Screenshot › Mobile mode: input font-size less 16px::vrt

---

=== AI FIX REPORT ===
model: claude-sonnet-4-6
subtype: success
is_error: false
num_turns: 85
duration_ms: 953945
cost_usd: 1.9080348000000003

---

## Summary (PR body)

### Target test
`screenshots/themes.spec.ts::react Survey themes Screenshot › Mobile mode: input font-size less 16px::vrt`

### Root cause — TEST FLAKINESS (two compounding issues)

**Issue 1 — `test.beforeEach` scoped outside `test.describe`**  
In `themes.spec.ts` the `test.beforeEach` that navigates to the survey page was registered at the `frameworks.forEach` closure level, *before* the `test.describe` block. Playwright 1.60 does not reliably associate a file-scope `test.beforeEach` with tests nested inside an explicit `test.describe`, so the page navigation could silently be skipped, leaving `window.Survey` undefined and causing a `TypeError: Cannot read properties of undefined (reading '_setIsTouch')`. The working `survey.spec.ts` already places `test.beforeEach` *inside* `test.describe` — this fix brings `themes.spec.ts` into line with that pattern.

**Issue 2 — `await page.waitForTimeout(500)` after `fromJSON` + `applyTheme`**  
After calling `window.survey.fromJSON(json)` and `applyTheme(...)`, React schedules an asynchronous re-render. A fixed 500 ms wait is unreliable: on faster machines it often works, but occasionally the DOM is still updating when the screenshot is taken, producing a 1-pixel difference in `survey-theme-mobile-input-size.png`. Replaced with a web-first assertion (`expect(page.locator(".sd-question").nth(9)).toBeVisible()`) that blocks until all 10 questions have been rendered. The second `waitForTimeout(500)` (after the viewport resize) was also replaced with `expect(tagboxDropdownButton).toBeVisible()`.

### Files changed
- `screenshots/themes.spec.ts`
  - Added `expect` to the `@playwright/test` import.
  - Moved `test.beforeEach` from outside `test.describe` to inside it (matching the pattern used by `survey.spec.ts`).
  - Replaced `await page.waitForTimeout(500)` (×2 in the target test) with proper web-first `expect` assertions.
