### PR TITLE
fix: prevent validateExpressions() from mutating paneldynamic survey.data

### DIFF
--- a/packages/survey-core/src/question_paneldynamic.ts
+++ b/packages/survey-core/src/question_paneldynamic.ts
@@ -282,20 +282,18 @@ export class QuestionPanelDynamicModel extends Question implements IDynamicItemM
     super.dispose();
     this.templateValue.dispose();
   }
-  private isValidatingExpressionsValue: boolean;
   public validateExpressions(options: IExpressionValidationOptions = { functions: true, variables: true, semantics: true }): IExpressionValidationResult[] {
-    this.isValidatingExpressionsValue = true;
-    try {
-      if (!this.useTemplatePanel) {
-        new QuestionPanelDynamicItem(this, this.template);
-      }
-      return super.validateExpressions(options);
-    } finally {
-      if (!this.useTemplatePanel) {
-        this.setTemplatePanelSurveyImpl();
-      }
-      this.isValidatingExpressionsValue = false;
+    if (!this.useTemplatePanel) {
+      new QuestionPanelDynamicItem(this, this.template);
     }
+    const res = super.validateExpressions(options);
+    if (!this.useTemplatePanel) {
+      this.setTemplatePanelSurveyImpl();
+    }
+    return res;
+  }
+  private get isValidatingExpressions(): boolean {
+    return !this.useTemplatePanel && this.template.data instanceof QuestionPanelDynamicItem;
   }
   public get isCompositeQuestion(): boolean { return true; }
   public get isContainer(): boolean { return true; }
@@ -2281,7 +2279,7 @@ export class QuestionPanelDynamicModel extends Question implements IDynamicItemM
   }
   private settingPanelCountBasedOnValue: boolean;
   private setPanelCountBasedOnValue() {
-    if (this.isValidatingExpressionsValue || this.isValueChangingInternally || this.useTemplatePanel) return;
+    if (this.isValidatingExpressions || this.isValueChangingInternally || this.useTemplatePanel) return;
     var val = this.value;
     var newPanelCount = val && Array.isArray(val) ? val.length : 0;
     if (newPanelCount == 0 && this.getPropertyValue("panelCount") > 0) {
@@ -2292,7 +2290,7 @@ export class QuestionPanelDynamicModel extends Question implements IDynamicItemM
     this.settingPanelCountBasedOnValue = false;
   }
   public setQuestionValue(newValue: any): void {
-    if (this.isValidatingExpressionsValue || this.settingPanelCountBasedOnValue) return;
+    if (this.isValidatingExpressions || this.settingPanelCountBasedOnValue) return;
     super.setQuestionValue(newValue, false);
     this.setPanelCountBasedOnValue();
     // Do not force-refresh nested panel questions while a child question updates panel data.
@@ -2403,7 +2401,7 @@ export class QuestionPanelDynamicModel extends Question implements IDynamicItemM
   }
   private isSetPanelItemData: HashTable<number> = {};
   updateItemValue(item: ISurveyData, name: string, val: any, isDeletingValue: boolean): void {
-    if (this.isValidatingExpressionsValue || item === this.template.data) return;
+    if (this.isValidatingExpressions || item === this.template.data) return;
     if (this.isSetPanelItemData[name] > this.maxCheckCount)
       return;
     if (!this.isSetPanelItemData[name]) {

--- a/packages/survey-core/src/question_paneldynamic.ts
+++ b/packages/survey-core/src/question_paneldynamic.ts
@@ -282,15 +282,20 @@ export class QuestionPanelDynamicModel extends Question implements IDynamicItemM
     super.dispose();
     this.templateValue.dispose();
   }
+  private isValidatingExpressionsValue: boolean;
   public validateExpressions(options: IExpressionValidationOptions = { functions: true, variables: true, semantics: true }): IExpressionValidationResult[] {
-    if (!this.useTemplatePanel) {
-      new QuestionPanelDynamicItem(this, this.template);
+    this.isValidatingExpressionsValue = true;
+    try {
+      if (!this.useTemplatePanel) {
+        new QuestionPanelDynamicItem(this, this.template);
+      }
+      return super.validateExpressions(options);
+    } finally {
+      if (!this.useTemplatePanel) {
+        this.setTemplatePanelSurveyImpl();
+      }
+      this.isValidatingExpressionsValue = false;
     }
-    const res = super.validateExpressions(options);
-    if (!this.useTemplatePanel) {
-      this.setTemplatePanelSurveyImpl();
-    }
-    return res;
   }
   public get isCompositeQuestion(): boolean { return true; }
   public get isContainer(): boolean { return true; }
@@ -2276,7 +2281,7 @@ export class QuestionPanelDynamicModel extends Question implements IDynamicItemM
   }
   private settingPanelCountBasedOnValue: boolean;
   private setPanelCountBasedOnValue() {
-    if (this.isValueChangingInternally || this.useTemplatePanel) return;
+    if (this.isValidatingExpressionsValue || this.isValueChangingInternally || this.useTemplatePanel) return;
     var val = this.value;
     var newPanelCount = val && Array.isArray(val) ? val.length : 0;
     if (newPanelCount == 0 && this.getPropertyValue("panelCount") > 0) {
@@ -2287,7 +2292,7 @@ export class QuestionPanelDynamicModel extends Question implements IDynamicItemM
     this.settingPanelCountBasedOnValue = false;
   }
   public setQuestionValue(newValue: any): void {
-    if (this.settingPanelCountBasedOnValue) return;
+    if (this.isValidatingExpressionsValue || this.settingPanelCountBasedOnValue) return;
     super.setQuestionValue(newValue, false);
     this.setPanelCountBasedOnValue();
     // Do not force-refresh nested panel questions while a child question updates panel data.
@@ -2398,7 +2403,7 @@ export class QuestionPanelDynamicModel extends Question implements IDynamicItemM
   }
   private isSetPanelItemData: HashTable<number> = {};
   updateItemValue(item: ISurveyData, name: string, val: any, isDeletingValue: boolean): void {
-    if (item === this.template.data) return;
+    if (this.isValidatingExpressionsValue || item === this.template.data) return;
     if (this.isSetPanelItemData[name] > this.maxCheckCount)
       return;
     if (!this.isSetPanelItemData[name]) {

--- a/packages/survey-core/tests/expressions/expressionValidationTest.ts
+++ b/packages/survey-core/tests/expressions/expressionValidationTest.ts
@@ -1,5 +1,6 @@
 import { IExpressionValidationResult } from "../../src/base";
 import { ExpressionErrorType } from "../../src/expressions/expressionError";
+import { Helpers } from "../../src/helpers";
 import { SurveyModel } from "../../src/survey";
 
 import { describe, test, expect } from "vitest";
@@ -763,6 +764,76 @@ describe("Expression Validation", () => {
     const results = survey.validateExpressions({ functions: true, variables: true, semantics: true });
     expect(results.length, "There are 0 invalid expressions").toBe(0);
     expect(q1.panelCount, "panelCount is 1 after validateExpressions").toBe(1);
+  });
+
+  test("validateExpressions() should not mutate survey data for paneldynamic with shared valueName and defaultValueExpression", () => {
+    const survey = new SurveyModel({
+      pages: [
+        {
+          name: "page1",
+          elements: [
+            {
+              type: "text",
+              name: "panelCountQuestion",
+              inputType: "number",
+            },
+          ],
+        },
+        {
+          name: "page2",
+          elements: [
+            {
+              type: "paneldynamic",
+              name: "dynamic1",
+              valueName: "sharedItems",
+              templateElements: [
+                {
+                  type: "text",
+                  name: "itemName",
+                  defaultValueExpression: "iif({panelIndex} == 0, 'You', 'Person ' + {panelIndex})",
+                },
+                {
+                  type: "expression",
+                  name: "itemLabel",
+                  expression: "iif({panelIndex} == 0, 'your', {panel.itemName} + 's')",
+                  visibleIf: "false",
+                },
+              ],
+              templateTabTitle: "{panel.itemName}",
+              bindings: {
+                panelCount: "panelCountQuestion",
+              },
+              displayMode: "tab",
+            },
+          ],
+        },
+        {
+          name: "page3",
+          elements: [
+            {
+              type: "paneldynamic",
+              name: "dynamic2",
+              templateElements: [],
+              valueName: "sharedItems",
+              panelCount: 1,
+            },
+          ],
+        },
+      ],
+    });
+    survey.setValue("panelCountQuestion", 4);
+    const dynamic1 = survey.getQuestionByName("dynamic1");
+    const dynamic2 = survey.getQuestionByName("dynamic2");
+    const dataBefore = Helpers.getUnbindValue(survey.data);
+    expect(survey.getValue("panelCountQuestion"), "panelCountQuestion before").toBe(4);
+    expect(dynamic1.panelCount, "dynamic1 panelCount before").toBe(4);
+
+    survey.validateExpressions();
+
+    expect(survey.getValue("panelCountQuestion"), "panelCountQuestion after").toBe(4);
+    expect(dynamic1.panelCount, "dynamic1 panelCount after").toBe(4);
+    expect(dynamic2.panelCount, "dynamic2 panelCount after").toBe(1);
+    expect(survey.data, "survey.data after").toEqual(dataBefore);
   });
 
   test("validateExpressions() incorrectly reports UnknownVariable in array functions #11082", () => {


### PR DESCRIPTION
Skip value and panelCount writes while validating expressions so shared valueName + defaultValueExpression no longer corrupt survey.data.