### PR TITLE
fix: run built-in validation before onServerValidateQuestions on Preview

### DIFF
--- a/packages/survey-core/src/survey.ts
+++ b/packages/survey-core/src/survey.ts
@@ -4291,6 +4291,7 @@ export class SurveyModel extends SurveyElementCore
     || !doComplete && (this.validationAllowSwitchPages || this.isValidateOnComplete) || isPreview && this.isValidateOnComplete;
     const doFunc = (): void => {
       if (isPreview) {
+        if (!this.isValidateOnComplete && this.doServerValidation(true, true)) return;
         this.showPreviewCore();
       } else {
         this.doCurrentPageCompleteCore(doComplete);
@@ -4618,8 +4619,7 @@ export class SurveyModel extends SurveyElementCore
    */
   public showPreview(): boolean {
     this.resetNavigationButton();
-    if (!this.isValidateOnComplete && this.doServerValidation(true, true)) return false;
-    if (!this.validateOnNavigate(true, true)) return false;
+    if (this.validateOnNavigate(true, true) === false) return false;
     return this.isShowingPreview;
   }
   private showPreviewCore(): void {

--- a/packages/survey-core/tests/surveyShowPreviewTests.ts
+++ b/packages/survey-core/tests/surveyShowPreviewTests.ts
@@ -512,6 +512,31 @@ describe("SurveyShowPreviewTests", () => {
     expect(counterServer, "Server validation is called").toBe(1);
     expect(counterPreview, "Showing preview is called").toBe(1);
   });
+  test("showPreview runs built-in validation before onServerValidateQuestions", () => {
+    const survey = new SurveyModel({
+      elements: [
+        { type: "text", name: "question1", isRequired: true },
+        { type: "text", name: "country", isRequired: true },
+      ],
+      showPreviewBeforeComplete: true,
+    });
+    let serverValidationCount = 0;
+    survey.onServerValidateQuestions.add((_, options) => {
+      serverValidationCount++;
+      options.complete();
+    });
+    expect(survey.showPreview()).toBe(false);
+    expect(survey.state).toBe("running");
+    expect(serverValidationCount).toBe(0);
+    expect(survey.getQuestionByName("question1").errors.length).toBe(1);
+    expect(survey.getQuestionByName("country").errors.length).toBe(1);
+
+    survey.setValue("question1", "value");
+    survey.setValue("country", "France");
+    expect(survey.showPreview()).toBe(true);
+    expect(survey.state).toBe("preview");
+    expect(serverValidationCount).toBe(1);
+  });
   test("showPreviewBeforeComplete = true and invisible matrix dropdown, Bug#3176", () => {
     var survey = new SurveyModel({
       showPreviewBeforeComplete: true,


### PR DESCRIPTION
showPreview() invoked server validation first and opened preview on complete(), skipping required and other client-side checks.