### PR TITLE
fix: dependency-skip misses case-insensitive references to dynamic pa…

### DIFF
--- a/packages/survey-core/src/conditions/conditionProcessValue.ts
+++ b/packages/survey-core/src/conditions/conditionProcessValue.ts
@@ -140,6 +140,8 @@ export class ValueGetter {
     for (let i = 0; i < path.length; i++) {
       res += (i > 0 ? "." : "") + path[i].name;
       if (keys.hasOwnProperty(res)) return res;
+      const lowerRes = res.toLowerCase();
+      if (lowerRes !== res && keys.hasOwnProperty(lowerRes)) return lowerRes;
     }
     return "";
   }

--- a/packages/survey-core/src/dynamicItemModelBase.ts
+++ b/packages/survey-core/src/dynamicItemModelBase.ts
@@ -36,6 +36,8 @@ export abstract class DynamicItemGetterContext extends QuestionItemValueGetterCo
   public getValue(params: IValueGetterContextGetValueParams): IValueGetterInfo {
     const path = params.path;
     if (path.length === 0) return undefined;
+    // context variables ({row.col1}, {PANEL.q1}, {prevRow.col1}, ...) are case-insensitive
+    const firstName = path[0].name.toLocaleLowerCase();
 
     if (path.length === 1) {
       const val = this.getItemValue(path[0].name);
@@ -43,14 +45,14 @@ export abstract class DynamicItemGetterContext extends QuestionItemValueGetterCo
         return { isFound: true, value: val, context: this };
       }
 
-      if (this.questionName && path[0].name === this.questionName) {
+      if (this.questionName && firstName === this.questionName.toLocaleLowerCase()) {
         const matrix = this.item.data;
         return { isFound: true, context: matrix.getValueGetterContext(), value: matrix.getFilteredData() };
       }
     }
 
     if (path.length > 1) {
-      const dIndex = path[0].name === this.getPrevName() ? -1 : path[0].name === this.getNextName() ? 1 : 0;
+      const dIndex = firstName === this.getPrevName().toLocaleLowerCase() ? -1 : firstName === this.getNextName().toLocaleLowerCase() ? 1 : 0;
       if (dIndex !== 0) {
         const index = this.visibleIndex + dIndex;
         const item = this.getVisibleItem(index);
@@ -63,7 +65,7 @@ export abstract class DynamicItemGetterContext extends QuestionItemValueGetterCo
     const res = this.getSpecificValue(params);
     if (res) return res;
 
-    const isVarPrefix = path[0].name === this.variableName;
+    const isVarPrefix = firstName === this.variableName.toLocaleLowerCase();
     if (isVarPrefix || !params.isRoot) {
       if (isVarPrefix) {
         path.shift();

--- a/packages/survey-core/src/dynamicItemModelBase.ts
+++ b/packages/survey-core/src/dynamicItemModelBase.ts
@@ -102,6 +102,11 @@ export abstract class DynamicItemGetterContext extends QuestionItemValueGetterCo
     names.forEach((name) => {
       if (name) {
         res[name] = this.item;
+        // expressions may reference variables in any case ({parentpanel.q1} vs "parentPanel")
+        const lowerName = name.toLowerCase();
+        if (lowerName !== name) {
+          res[lowerName] = this.item;
+        }
       }
     });
     return res;

--- a/packages/survey-core/src/question_matrixdropdownbase.ts
+++ b/packages/survey-core/src/question_matrixdropdownbase.ts
@@ -213,7 +213,7 @@ export class MatrixRowGetterContext extends DynamicItemGetterContext {
   }
   protected getSpecificValue(params: IValueGetterContextGetValueParams): IValueGetterInfo {
     const path = params.path;
-    if (path.length > 1 && path[0].name === settings.expressionVariables.totalRow) {
+    if (path.length > 1 && path[0].name.toLocaleLowerCase() === settings.expressionVariables.totalRow.toLocaleLowerCase()) {
       const totalRow = <IObjectValueContext>(<any>this.row.data).visibleTotalRow;
       if (!!totalRow) {
         path[0].name = "row";

--- a/packages/survey-core/tests/question_matrixdynamictests.ts
+++ b/packages/survey-core/tests/question_matrixdynamictests.ts
@@ -9648,4 +9648,66 @@ describe("Survey_QuestionMatrixDynamic", () => {
     // The rendered table must reset and expose the delete button again.
     expect(matrix.renderedTable.hasRemoveRows).toBeTruthy();
   });
+  test("cell visibleIf with {row.x} and {prevRow.x} is re-evaluated on value change, dependency-skip keeps row context variables", () => {
+    const survey = new SurveyModel({
+      elements: [
+        {
+          type: "matrixdynamic",
+          name: "matrix",
+          rowCount: 2,
+          columns: [
+            { name: "Column 1", cellType: "text" },
+            { name: "col2", cellType: "text", visibleIf: "{row.Column 1} = 1" },
+            { name: "col3", cellType: "text", visibleIf: "{prevRow.Column 1} = 1" },
+          ],
+        },
+      ],
+    });
+    const matrix = <QuestionMatrixDynamicModel>survey.getQuestionByName("matrix");
+    const rows = matrix.visibleRows;
+    const cell = (r: number, c: number): Question => rows[r].cells[c].question;
+    expect(cell(0, 1).isVisible, "row0 col2 is hidden by default").toBeFalsy();
+    expect(cell(1, 2).isVisible, "row1 col3 is hidden by default").toBeFalsy();
+    cell(0, 0).value = 1;
+    expect(cell(0, 1).isVisible, "row0 col2 becomes visible, {row.x}").toBeTruthy();
+    expect(cell(1, 2).isVisible, "row1 col3 becomes visible, {prevRow.x}").toBeTruthy();
+    cell(0, 0).value = 2;
+    expect(cell(0, 1).isVisible, "row0 col2 is hidden again").toBeFalsy();
+    expect(cell(1, 2).isVisible, "row1 col3 is hidden again").toBeFalsy();
+  });
+  test("row context variables in expressions are case-insensitive: {ROW.x}, {prevrow.x}, {NextRow.x}, {totalrow.x}", () => {
+    const survey = new SurveyModel({
+      elements: [
+        {
+          type: "matrixdynamic",
+          name: "matrix",
+          rowCount: 2,
+          columns: [
+            { name: "Column 1", cellType: "text", totalType: "sum" },
+            { name: "col2", cellType: "text", visibleIf: "{ROW.Column 1} = 1" },
+            { name: "col3", cellType: "text", visibleIf: "{prevrow.Column 1} = 1" },
+            { name: "col4", cellType: "text", visibleIf: "{NextRow.Column 1} = 2" },
+            { name: "col5", cellType: "text", visibleIf: "{totalrow.Column 1} = 3" },
+          ],
+        },
+      ],
+    });
+    const matrix = <QuestionMatrixDynamicModel>survey.getQuestionByName("matrix");
+    const rows = matrix.visibleRows;
+    const cell = (r: number, c: number): Question => rows[r].cells[c].question;
+    expect(cell(0, 1).isVisible, "row0 {ROW.x} is hidden by default").toBeFalsy();
+    expect(cell(1, 2).isVisible, "row1 {prevrow.x} is hidden by default").toBeFalsy();
+    expect(cell(0, 3).isVisible, "row0 {NextRow.x} is hidden by default").toBeFalsy();
+    expect(cell(0, 4).isVisible, "row0 {totalrow.x} is hidden by default").toBeFalsy();
+    cell(0, 0).value = 1;
+    cell(1, 0).value = 2;
+    expect(cell(0, 1).isVisible, "row0 {ROW.x} becomes visible").toBeTruthy();
+    expect(cell(1, 2).isVisible, "row1 {prevrow.x} becomes visible").toBeTruthy();
+    expect(cell(0, 3).isVisible, "row0 {NextRow.x} becomes visible").toBeTruthy();
+    expect(cell(0, 4).isVisible, "row0 {totalrow.x} becomes visible, 1 + 2 = 3").toBeTruthy();
+    cell(0, 0).value = 5;
+    expect(cell(0, 1).isVisible, "row0 {ROW.x} is hidden again").toBeFalsy();
+    expect(cell(1, 2).isVisible, "row1 {prevrow.x} is hidden again").toBeFalsy();
+    expect(cell(0, 4).isVisible, "row0 {totalrow.x} is hidden again, 5 + 2 = 7").toBeFalsy();
+  });
 });

--- a/packages/survey-core/tests/question_paneldynamic_tests.ts
+++ b/packages/survey-core/tests/question_paneldynamic_tests.ts
@@ -2463,6 +2463,33 @@ describe("Survey_QuestionPanelDynamic", () => {
     expect(question5.isVisible, "question5 becomes visible, {ParentPanel.x}").toBeTruthy();
   });
 
+  test("panel context variables in expressions are case-insensitive: {PANEL.x}, {prevpanel.x}", () => {
+    const survey = new SurveyModel({
+      elements: [
+        {
+          type: "paneldynamic",
+          name: "pd",
+          panelCount: 2,
+          templateElements: [
+            { type: "text", name: "q1" },
+            { type: "text", name: "q2", visibleIf: "{PANEL.q1} = 1" },
+            { type: "text", name: "q3", visibleIf: "{prevpanel.q1} = 1" },
+          ],
+        },
+      ],
+    });
+    const panels = (<QuestionPanelDynamicModel>survey.getQuestionByName("pd")).panels;
+    const q = (p: number, name: string) => panels[p].getQuestionByName(name);
+    expect(q(0, "q2").isVisible, "panel0 {PANEL.x} is hidden by default").toBeFalsy();
+    expect(q(1, "q3").isVisible, "panel1 {prevpanel.x} is hidden by default").toBeFalsy();
+    q(0, "q1").value = 1;
+    expect(q(0, "q2").isVisible, "panel0 {PANEL.x} becomes visible").toBeTruthy();
+    expect(q(1, "q3").isVisible, "panel1 {prevpanel.x} becomes visible").toBeTruthy();
+    q(0, "q1").value = 2;
+    expect(q(0, "q2").isVisible, "panel0 {PANEL.x} is hidden again").toBeFalsy();
+    expect(q(1, "q3").isVisible, "panel1 {prevpanel.x} is hidden again").toBeFalsy();
+  });
+
   test("Page.ensureRowsVisibility updates rows in dynamic panel", () => {
     const survey = new SurveyModel({
       pages: [

--- a/packages/survey-core/tests/question_paneldynamic_tests.ts
+++ b/packages/survey-core/tests/question_paneldynamic_tests.ts
@@ -2413,6 +2413,56 @@ describe("Survey_QuestionPanelDynamic", () => {
     expect(question4.visibleChoices.length, "There are two visible choices by now").toBe(2);
   });
 
+  test("visibleIf with lower-case {parentpanel.x} is re-evaluated on value change, dependency-skip is case-insensitive", () => {
+    const survey = new SurveyModel({
+      elements: [
+        {
+          type: "paneldynamic",
+          name: "question1",
+          panelCount: 1,
+          templateElements: [
+            {
+              type: "checkbox",
+              name: "question2",
+              choices: ["item1", "item2", "item3"],
+            },
+            {
+              type: "paneldynamic",
+              name: "question3",
+              panelCount: 1,
+              templateElements: [
+                {
+                  type: "text",
+                  name: "question4",
+                  visibleIf: "{parentpanel.question2} contains 'item1'",
+                },
+                {
+                  type: "text",
+                  name: "question5",
+                  visibleIf: "{ParentPanel.question2} contains 'item2'",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const rootPanel = <QuestionPanelDynamicModel>survey.getQuestionByName("question1");
+    const rootPanelEl1 = rootPanel.panels[0];
+    const question2 = rootPanelEl1.getQuestionByName("question2");
+    const childPanel = <QuestionPanelDynamicModel>rootPanelEl1.getQuestionByName("question3");
+    const question4 = childPanel.panels[0].getQuestionByName("question4");
+    const question5 = childPanel.panels[0].getQuestionByName("question5");
+    expect(question4.isVisible, "question4 is hidden by default").toBeFalsy();
+    expect(question5.isVisible, "question5 is hidden by default").toBeFalsy();
+    question2.value = ["item1"];
+    expect(question4.isVisible, "question4 becomes visible, {parentpanel.x}").toBeTruthy();
+    expect(question5.isVisible, "question5 is still hidden").toBeFalsy();
+    question2.value = ["item2"];
+    expect(question4.isVisible, "question4 is hidden again").toBeFalsy();
+    expect(question5.isVisible, "question5 becomes visible, {ParentPanel.x}").toBeTruthy();
+  });
+
   test("Page.ensureRowsVisibility updates rows in dynamic panel", () => {
     const survey = new SurveyModel({
       pages: [


### PR DESCRIPTION
…nel context variables

Expression variables are resolved case-insensitively ({parentpanel.q1} matches the parentPanel context variable), but the changed-keys check used by the visibleIf/enableIf/requiredIf dependency-skip compared names case-sensitively. A question inside a nested dynamic panel with visibleIf "{parentpanel.q1} ..." was not re-evaluated when the parent panel value changed.

- getContextKeys: register lower-case aliases for context variable names
- getFirstNameByKeys: fall back to a lower-case key lookup per path step