### PR TITLE
fix: dateDiff minutes returns wrong value across hour boundary

### DIFF
--- a/packages/survey-core/src/functionsfactory.ts
+++ b/packages/survey-core/src/functionsfactory.ts
@@ -264,8 +264,8 @@ function dateDiff(params: any[]): any {
   if (!Array.isArray(params) || params.length < 2 || !params[0] || !params[1]) return null;
   const type = (params.length > 2 ? params[2] : "") || "days";
   if (type === "hours" || type === "minutes" || type === "seconds") {
-    const date1: any = createDate("function-dateDiffMonths", params[0]);
-    const date2: any = createDate("function-dateDiffMonths", params[1]);
+    const date1: any = createDate("function-dateDiff", params[0]);
+    const date2: any = createDate("function-dateDiff", params[1]);
     const diffMs = Math.abs(date2 - date1);
     if (type === "hours") return Math.ceil(diffMs / (1000 * 60 * 60));
     if (type === "minutes") return Math.ceil(diffMs / (1000 * 60));

--- a/packages/survey-core/src/functionsfactory.ts
+++ b/packages/survey-core/src/functionsfactory.ts
@@ -263,23 +263,15 @@ FunctionFactory.Instance.register("age", age);
 function dateDiff(params: any[]): any {
   if (!Array.isArray(params) || params.length < 2 || !params[0] || !params[1]) return null;
   const type = (params.length > 2 ? params[2] : "") || "days";
-  const isHours = type === "hours" || type === "minutes";
-  const dType = isHours ? "days" : type;
-  let days = dateDiffMonths(params[0], params[1], dType);
-  if (isHours) {
-    const date1 = createDate("function-dateDiffMonths", params[0]);
-    const date2 = createDate("function-dateDiffMonths", params[1]);
-    if (date2.getHours() > date1.getHours() || (type !== "hours" && date2.getHours() === date1.getHours() && date2.getMinutes() > date1.getMinutes())) {
-      days -= 1;
-    }
-    let hours = days * 24 + date2.getHours() - date1.getHours();
-    if (type === "hours") return hours;
-    if (date2.getMinutes() < date1.getMinutes()) {
-      hours -= 1;
-    }
-    return hours * 60 + date2.getMinutes() - date1.getMinutes();
+  if (type === "hours" || type === "minutes" || type === "seconds") {
+    const date1: any = createDate("function-dateDiffMonths", params[0]);
+    const date2: any = createDate("function-dateDiffMonths", params[1]);
+    const diffMs = Math.abs(date2 - date1);
+    if (type === "hours") return Math.ceil(diffMs / (1000 * 60 * 60));
+    if (type === "minutes") return Math.ceil(diffMs / (1000 * 60));
+    return Math.ceil(diffMs / 1000);
   }
-  return days;
+  return dateDiffMonths(params[0], params[1], type);
 }
 FunctionFactory.Instance.register("dateDiff", dateDiff);
 

--- a/packages/survey-core/tests/expressions/expressionParserTest.ts
+++ b/packages/survey-core/tests/expressions/expressionParserTest.ts
@@ -368,12 +368,46 @@ QUnit.test("Run dateDiff by days", function(assert) {
   (<any>values).d1 = undefined;
   assert.equal(runner.run(values), null, "a value is undefined");
 });
+QUnit.test("Run dateDiff by hours", function(assert) {
+  const runner = new ExpressionRunner("dateDiff({d1}, {d2}, 'hours')");
+  const d1 = new Date("2021-02-02");
+  const d2 = new Date("2021-02-03");
+  d1.setHours(1, 0, 0, 0);
+  d2.setHours(12, 0, 0, 0);
+  const values = { d1: d1, d2: d2 };
+  assert.equal(runner.run(values), 24 + 11, "35 hours");
+  (<any>values).d1 = undefined;
+  assert.equal(runner.run(values), null, "a value is undefined");
+});
+QUnit.test("Run dateDiff by minutes", function(assert) {
+  const runner = new ExpressionRunner("dateDiff({d1}, {d2}, 'minutes')");
+  const d1 = new Date("2021-02-01");
+  const d2 = new Date("2021-02-02");
+  d1.setHours(1, 10, 0, 0);
+  d2.setHours(12, 25, 0, 0);
+  const values = { d1: d1, d2: d2 };
+  assert.equal(runner.run(values), (24 + 11) * 60 + 15, "minutes across days");
+  (<any>values).d1 = undefined;
+  assert.equal(runner.run(values), null, "a value is undefined");
+});
 QUnit.test("Run dateDiff by minutes Bug#10177", function(assert) {
   const runner = new ExpressionRunner("dateDiff({d1}, {d2}, 'minutes')");
   const d1 = new Date("2025-07-25T13:00");
   const d2 = new Date("2025-07-25T13:05");
   const values = { d1: d1, d2: d2 };
-  assert.equal(runner.run(values), 5, "minutes");
+  assert.equal(runner.run(values), 5, "minutes same hour");
+});
+QUnit.test("Run dateDiff by minutes across hour boundary", function(assert) {
+  const runner = new ExpressionRunner("dateDiff({start}, {end}, 'minutes')");
+  const values = { start: "2026-07-31T00:58", end: "2026-07-31T01:05" };
+  assert.equal(runner.run(values), 7, "7 minutes from 00:58 to 01:05");
+});
+QUnit.test("Run dateDiff by seconds", function(assert) {
+  const runner = new ExpressionRunner("dateDiff({d1}, {d2}, 'seconds')");
+  const d1 = new Date("2025-07-25T02:13:48");
+  const d2 = new Date("2025-07-25T02:15:05");
+  const values = { d1: d1, d2: d2 };
+  assert.equal(runner.run(values), 77, "seconds");
 });
 QUnit.test("Run dateAdd() for days", function(assert) {
   const d1 = new Date("2021-01-01");


### PR DESCRIPTION
## Summary
- Fix `dateDiff(..., ''hours''|''minutes''|''seconds'')` to use a millisecond delta (same approach as v2/master)
- The old calendar-day adjustment incorrectly decremented days when crossing an hour, so `dateDiff(''2026-07-31T00:58'', ''2026-07-31T01:05'', ''minutes'')` returned `-1493` instead of `7`
- Add regression tests for hours, minutes (including hour-boundary), and seconds

## Test plan
- [ ] `dateDiff({start}, {end}, ''minutes'')` with start `2026-07-31T00:58` and end `2026-07-31T01:05` returns `7`
- [ ] Existing Bug#10177 case (`13:00` → `13:05`) still returns `5`
- [ ] Hours/seconds cases in `expressionParserTest.ts` pass