### PR TITLE
Stabilize flaky test 'Mobile mode: input font-size less 16px' from 'themes.spec.ts' on branch 'master'

### DIFF
--- a/screenshots/themes.spec.ts
+++ b/screenshots/themes.spec.ts
@@ -428,21 +428,23 @@ frameworks.forEach(framework => {
         (window as any).Survey.ListModel.MINELEMENTCOUNT = 2;
       });
       await page.setViewportSize({ width: 400, height: 2000 });
-      await initSurvey(page, framework, {});
-      await page.evaluate((json) => {
-        window["survey"].onOpenDropdownMenu.add((sender, options) => {
-          if (options.menuType === "popup") options.menuType = "overlay";
+      // Register the event handler and apply the theme via afterInitializeModelCallback so
+      // they are set on the model BEFORE React's initial root.render() call. This avoids
+      // the previous double-render race (initSurvey({}) -> fromJSON -> applyTheme) that
+      // caused a 1-pixel flaky difference in the screenshot.
+      await initSurvey(page, framework, jsonWithInputs, false, undefined, async () => {
+        await page.evaluate(() => {
+          window["survey"].onOpenDropdownMenu.add((sender, options) => {
+            if (options.menuType === "popup") options.menuType = "overlay";
+          });
+          window["survey"].applyTheme({
+            "cssVariables": {
+              "--sjs-font-editorfont-size": "12px",
+              "--sjs-font-size": "20px"
+            }
+          });
         });
-        window["survey"].fromJSON(json);
-        window["survey"].applyTheme({
-          "cssVariables": {
-            "--sjs-font-editorfont-size": "12px",
-            "--sjs-font-size": "20px"
-          }
-        });
-      }, jsonWithInputs);
-      // Wait for React to finish re-rendering all 10 questions after fromJSON
-      await expect(page.locator(".sd-question").nth(9)).toBeVisible();
+      });
       await compareScreenshot(page, ".sd-root-modern", "survey-theme-mobile-input-size.png");
 
       await page.setViewportSize({ width: 400, height: 1000 });


### PR DESCRIPTION
Automated flaky-test stabilization by Claude Code (headless).

Branch: master
Target test: screenshots/themes.spec.ts::react Survey themes Screenshot › Mobile mode: input font-size less 16px::vrt

---

=== AI FIX REPORT ===
model: claude-sonnet-4-6
subtype: success
is_error: false
num_turns: 29
duration_ms: 428694
cost_usd: 0.7373386500000001

10/10 passes. The fix is stable.

---

## PR Summary

### Test: `screenshots/themes.spec.ts :: react Survey themes Screenshot › Mobile mode: input font-size less 16px :: vrt`

**Root cause — TEST FLAKINESS (double-render race)**

The test used a two-step survey initialization:
1. `initSurvey(page, framework, {})` — created an empty survey, triggering React's first `root.render()`
2. A follow-up `page.evaluate(...)` called `survey.fromJSON(jsonWithInputs)` + `survey.applyTheme(...)`, forcing React into a second render pass

Even with the existing guard (`await expect(page.locator(".sd-question").nth(9)).toBeVisible()`), the `applyTheme` CSS-variable cascade could still be mid-reflow when `toHaveScreenshot` captured the screenshot. Playwright's built-in stability check detects *position* changes but not sub-pixel border/layout reflows, leaving a 1-pixel window for a timing difference.

**Fix**

Replaced the two-step init with a single call to `initSurvey(page, framework, jsonWithInputs, ...)`, using the existing `afterInitializeModelCallback` parameter to register the `onOpenDropdownMenu` handler and call `applyTheme` **before** React's initial `root.render()`. Since the model already carries the theme when React first renders, there is only one render pass — no second layout reflow, no timing window.

**Files changed**
- `screenshots/themes.spec.ts`
