### PR TITLE
Keep checked checkbox style when question has validation error

### DIFF
--- a/packages/survey-core/src/default-theme/blocks/sd-item.scss
+++ b/packages/survey-core/src/default-theme/blocks/sd-item.scss
@@ -36,6 +36,11 @@
     background-color: var(--sjs2-color-component-check-false-disabled-bg);
     box-shadow: var(--sjs2-border-effect-component-check-false-disabled);
   }
+
+  &.sd-item--checked .sd-item__decorator {
+    background-color: var(--sjs2-color-component-check-true-disabled-bg);
+    box-shadow: var(--sjs2-border-effect-component-check-true-disabled);
+  }
 }
 
 .sd-item--readonly.sd-item--readonly {
@@ -108,7 +113,7 @@
   color: $font-questiontitle-color;
 }
 
-.sd-item--error .sd-item__decorator {
+.sd-item--error:not(.sd-item--checked) .sd-item__decorator {
   background-color: var(--sjs2-color-component-check-false-invalid-bg);
   box-shadow: var(--sjs2-border-effect-component-check-false-invalid);
 }


### PR DESCRIPTION
## Summary
- Do not apply error styles to checked choice items — a selected item is not invalid
- Apply checked+disabled tokens for selected disabled items
- Only `sd-item.scss` (no `base-theme` token changes)

## Note
Merge **after** https://github.com/surveyjs/survey-library/pull/11697 (reverts the accidental direct push to `V3`).

## Test plan
- [ ] Checkbox with `minSelectedChoices` / `maxSelectedChoices`, select fewer than min, call `validate(true)`
- [ ] Checked items keep normal checked appearance
- [ ] Unchecked items show invalid styling; error message still shown
