### PR TITLE
Stabilize flaky test 'Check file question mobile mode' from 'file.spec.ts' on branch 'master'

### DIFF
--- a/screenshots/file.spec.ts
+++ b/screenshots/file.spec.ts
@@ -222,6 +222,12 @@ frameworks.forEach(framework => {
         question.value = [].concat(question.value).sort((a: any, b: any) => order.indexOf(a.name) - order.indexOf(b.name));
       });
 
+      // Wait for the question model to rebuild fileIndexAction after the value sort
+      await page.waitForFunction(() => {
+        const question = (window as any).survey.getQuestionByName("file_question");
+        return !!(question && question.fileIndexAction);
+      });
+
       await page.evaluate(() => {
         const question = (window as any).survey.getQuestionByName("file_question");
         question.indexToShow = 0;


### PR DESCRIPTION
Automated flaky-test stabilization by Claude Code (headless).

Branch: master
Target test: screenshots/file.spec.ts::react File Screenshot › Check file question mobile mode::vrt

---

=== AI FIX REPORT ===
model: claude-sonnet-4-6
subtype: success
is_error: false
num_turns: 8
duration_ms: 92272
cost_usd: 0.2051562

All 5 runs pass. The fix is confirmed stable.

---

## PR Summary

### Target test
`screenshots/file.spec.ts :: react File Screenshot › Check file question mobile mode :: vrt`

### Root cause — Test flakiness (timing race)

After reassigning `question.value` with a sorted array inside `page.evaluate()`, the SurveyJS question model triggers an **async internal rebuild** that creates (or re-creates) `fileIndexAction`. Because the next `page.evaluate()` runs immediately after the sort, `fileIndexAction` is sometimes still `undefined`, causing:

```
TypeError: Cannot set properties of undefined (setting 'title')
```

This is a pure test-side race condition — the product itself behaves correctly once its async update settles.

### Fix

Inserted a `page.waitForFunction()` between the two `evaluate()` blocks. It polls the page until `question.fileIndexAction` is truthy before the code attempts to read/write its `title` property. This is the idiomatic Playwright web-first approach for waiting on in-page model state.

### Files changed
- `screenshots/file.spec.ts` — added `page.waitForFunction()` guard before the `fileIndexAction.title` access.
