### PR TITLE
refactor: use Object.create(null) for registries to avoid prototype p…

### DIFF
--- a/packages/survey-core/src/tester/test-checks.ts
+++ b/packages/survey-core/src/tester/test-checks.ts
@@ -48,7 +48,9 @@ export function isCheckAllowedForKind(check: ISurveyTestCheckHandler, kind: Surv
 
 export class SurveyTestCheckFactory {
   public static Instance: SurveyTestCheckFactory = new SurveyTestCheckFactory();
-  private checks: { [name: string]: ISurveyTestCheckHandler } = {};
+  // Object.create(null): a step names its checks, and "toString" must not resolve to a prototype
+  // member instead of failing with unknownCheck.
+  private checks: { [name: string]: ISurveyTestCheckHandler } = Object.create(null);
   public register(check: ISurveyTestCheckHandler): void {
     this.checks[check.name] = check;
   }
@@ -120,12 +122,36 @@ SurveyTestCommandFactory.Instance.register({
           target.name, { check: checkName, payloadType: handler.payloadType });
         continue;
       }
-      const outcome = await handler.check(context, target, expected);
+      // A handler is registered code, and a registration from untyped JavaScript can throw or answer
+      // with nothing. Either way it is this pair that failed, so it is reported like every refusal
+      // above it and the loop goes on: one broken check must not take the other checks of the step
+      // with it, which is the invariant this loop exists to keep.
+      let outcome: ISurveyTestCheckOutcome | Array<ISurveyTestCheckOutcome> = undefined;
+      try {
+        outcome = await handler.check(context, target, expected);
+      } catch(e) {
+        addPairIssue(context, SurveyTestIssueCodes.unexpectedError,
+          "The check \"" + checkName + "\" of the target \"" + target.name + "\" threw an error: " +
+          getErrorText(e), target.name, { check: checkName });
+        continue;
+      }
       const outcomes = Array.isArray(outcome) ? outcome : [outcome];
+      if (outcomes.some(item => !item)) {
+        addPairIssue(context, SurveyTestIssueCodes.unexpectedError,
+          "The check \"" + checkName + "\" of the target \"" + target.name +
+          "\" returned no outcome. A check answers with an outcome object, or with an array of them.",
+          target.name, { check: checkName });
+        continue;
+      }
       outcomes.forEach(item => addOutcome(context, target, checkName, expected, item));
     }
   },
 });
+
+function getErrorText(error: any): string {
+  if (!error) return "undefined";
+  return typeof error.message === "string" ? error.message : String(error);
+}
 
 function getCheckPayloadText(handler: ISurveyTestCheckHandler): string {
   return !!handler.payloadText ? handler.payloadText : getTestPayloadTypeText(handler.payloadType);
@@ -194,16 +220,24 @@ function createOutcome(subject: string, actual: any, expected: any, ignoreOrder?
 function getElementQuestions(obj: any): Array<any> {
   return !!obj && Array.isArray(obj.questions) ? obj.questions : [];
 }
+// getAllErrors() is what a matrix, a dynamic panel and a multipletext override to add the errors of
+// their cells, panels and items; "errors" holds the errors of the question itself only. Reading
+// "errors" here made the question checks contradict the survey check of the same run.
+function getQuestionErrors(question: any): Array<any> {
+  const errors: Array<any> = typeof question.getAllErrors === "function" ? question.getAllErrors() : question.errors;
+  return Array.isArray(errors) ? errors : [];
+}
 function getErrorTexts(target: ISurveyTestTarget): Array<string> {
   const obj: any = target.obj;
   const questions: Array<any> = target.kind === "question" ? [obj] : getElementQuestions(obj);
   const res: Array<string> = [];
   questions.forEach(question => {
-    const errors: Array<any> = Array.isArray(question.errors) ? question.errors : [];
-    errors.forEach(error => res.push(error.getText()));
+    getQuestionErrors(question).forEach(error => res.push(error.getText()));
   });
   return res;
 }
+// "errors" and not getAllErrors() here on purpose: the list already holds the nested questions, so
+// asking a container for the errors of its children would count every one of them twice.
 function getSurveyErrorTexts(context: ISurveyTestContext): Array<string> {
   const res: Array<string> = [];
   (<any>context.survey).getAllQuestions(false, false, true).forEach((question: any) => {

--- a/packages/survey-core/src/tester/test-commands.ts
+++ b/packages/survey-core/src/tester/test-commands.ts
@@ -79,7 +79,9 @@ export function formatTestValue(val: any): string {
 
 export class SurveyTestCommandFactory {
   public static Instance: SurveyTestCommandFactory = new SurveyTestCommandFactory();
-  private commands: { [name: string]: ISurveyTestCommand } = {};
+  // Object.create(null): a step names its command, and "toString" must not resolve to a prototype
+  // member instead of failing with unknownCommand.
+  private commands: { [name: string]: ISurveyTestCommand } = Object.create(null);
   public register(command: ISurveyTestCommand): void {
     this.commands[command.name] = command;
   }
@@ -521,6 +523,15 @@ function hasChoices(question: any): boolean {
 function getChoiceValues(question: any): Array<any> {
   return question.visibleChoices.map((item: any) => item.value);
 }
+// A choice with "showCommentArea" is selected as { value, comment }: that is the form the model itself
+// produces and stores - QuestionSelectBase.getChoiceValue - and getItemByValue unwraps it exactly like
+// this before it looks the choice up. The comment travels with the value; only the value is a choice.
+function getSelectedChoiceValue(value: any): any {
+  if (!!value && typeof value === "object" && !Array.isArray(value) && !Helpers.isValueEmpty(value.value)) {
+    return value.value;
+  }
+  return value;
+}
 function isMultiSelectQuestion(question: any): boolean {
   if (typeof question.multiSelect === "boolean") return question.multiSelect;
   return typeof question.maxSelectedChoices === "number";
@@ -560,7 +571,7 @@ function checkChoices(context: ISurveyTestContext, question: any, value: any, pa
       "the question takes a single choice value, and the value is an array: " + formatTestValue(value) + ".");
   }
   const available = getChoiceValues(question);
-  const values: Array<any> = isMulti ? value : [value];
+  const values: Array<any> = (isMulti ? value : [value]).map((item: any) => getSelectedChoiceValue(item));
   values.forEach(item => {
     if (available.some(choice => Helpers.isTwoValueEquals(choice, item))) return;
     const availableText = available.map(choice => formatTestValue(choice)).join(", ");
@@ -731,11 +742,28 @@ function setDynamicMatrixValue(context: ISurveyTestContext, question: any, value
     canAdd: () => question.canAddRow !== false, canProperty: "canAddRow",
     getCount: () => question.rowCount,
   });
+  // The generated rows, not the visible ones: their order is the order of the question value, and
+  // "visibleRows" is that list filtered by "rowsVisibleIf". Indexing the filtered list would put the
+  // value of one row into another and drop the last one without saying so.
+  const rows: Array<any> = getGeneratedMatrixRows(question);
   value.forEach((rowValue: any, index: number) => {
-    const row = question.visibleRows[index];
+    const rowPath = path + "[" + index + "]";
+    const row = rows[index];
     if (!row) return;
-    setMatrixCellValues(context, question, row, rowValue, path + "[" + index + "]");
+    if (row.isVisible === false) {
+      throw notEnterable(rowPath, question,
+        "the row is hidden by the \"rowsVisibleIf\" condition (" + question.rowsVisibleIf +
+        "), so a respondent cannot fill it in.", { cause: "rowsVisibleIf", rowsVisibleIf: question.rowsVisibleIf });
+    }
+    setMatrixCellValues(context, question, row, rowValue, rowPath);
   });
+}
+// generatedVisibleRows holds every row the question created, in value order; it is undefined until
+// the rows are generated, and visibleRows generates them on read.
+function getGeneratedMatrixRows(question: any): Array<any> {
+  const visible = question.visibleRows;
+  const generated = question.generatedVisibleRows;
+  return Array.isArray(generated) ? generated : (Array.isArray(visible) ? visible : []);
 }
 
 function setCellMatrixValue(context: ISurveyTestContext, question: any, value: any, path: string): void {
@@ -1224,14 +1252,18 @@ function addBlockedWarning(context: ISurveyTestContext, code: string, action: st
   const page: any = survey.currentPage;
   if (!!page && Array.isArray(page.questions)) {
     page.questions.forEach((question: any) => {
-      if (!question.errors || question.errors.length === 0) return;
+      // getAllErrors() so that a matrix or a dynamic panel whose cells are the reason reports it;
+      // "errors" holds the errors of the question itself and stays empty for those types.
+      const errors: Array<any> = typeof question.getAllErrors === "function"
+        ? question.getAllErrors() : question.errors;
+      if (!Array.isArray(errors) || errors.length === 0) return;
       blocking.push({
         name: question.name,
         jsonPath: getJsonPath(question),
         isRequired: question.isRequired === true,
         isVisible: question.isVisibleInSurvey !== false,
         isEmpty: question.isEmpty(),
-        errors: question.errors.map((error: any) => error.getText()),
+        errors: errors.map((error: any) => error.getText()),
       });
     });
   }

--- a/packages/survey-core/src/tester/test-context.ts
+++ b/packages/survey-core/src/tester/test-context.ts
@@ -63,7 +63,9 @@ export class SurveyTestDateProvider implements ISurveyDateProvider {
 export class SurveyTestContext implements ISurveyTestContext {
   private surveyValue: SurveyModel;
   private resolver: SurveyTestTargetResolver;
-  private targetCache: { [path: string]: ISurveyTestTarget } = {};
+  // Object.create(null): the keys are target names a case writes, and a question named "constructor"
+  // has to be addressable rather than resolve to a prototype member.
+  private targetCache: { [path: string]: ISurveyTestTarget } = Object.create(null);
   private dateProviderValue: SurveyTestDateProvider;
   private currentStep: ISurveyTestStepResult;
   private resetCacheFunc: () => void;

--- a/packages/survey-core/src/tester/test-diagnostics.ts
+++ b/packages/survey-core/src/tester/test-diagnostics.ts
@@ -24,7 +24,9 @@ export interface ISurveyTestExpressionTrace {
   // Only the names the expression reads. Start data is shared and can be large, and a failure that
   // dumps the whole data object buries the two values that mattered.
   values: { [name: string]: any };
-  result: any;
+  // What the expression evaluates to now, and undefined when it was not evaluated: an expression that
+  // calls a function is never re-run here, because running it would call that function a second time.
+  result?: any;
   // Names that resolve to nothing at all: no question, no calculated value, no variable.
   unknownNames?: Array<string>;
   // The closest existing name for an entry of unknownNames, when there is one.
@@ -331,7 +333,11 @@ export function getExpressionTrace(owner: any, expression: string): ISurveyTestE
     res.values[name] = processValue.getValue(name);
     if (!isKnownExpressionName(survey, processValue, name)) unknownNames.push(name);
   });
-  if (runner.canRun() && !runner.isAsync) {
+  // Only an expression that calls nothing is evaluated here. Running one that calls a function would
+  // call it a second time - the stub dispatcher routes by survey and its cache is off on purpose, so a
+  // stub that reports a failure reports it twice and a handler the application supplied runs twice.
+  // A diagnostic that changes the survey it explains is worse than no diagnostic.
+  if (runner.canRun() && !runner.isAsync && !runner.hasFunction()) {
     res.result = runner.runValues(values, !!survey ? survey.getFilteredProperties() : undefined);
   }
   if (unknownNames.length > 0) {
@@ -375,8 +381,10 @@ export class SurveyTestDiagnostics {
   private blocked: ISurveyTestBlockedRecord;
   // The question, not the record: a run that clears an invisible value and passes never pays for the
   // path of a node nobody asks about.
-  private cleared: { [name: string]: { stepIndex: number, question: any } } = {};
-  private reportedClears: { [key: string]: boolean } = {};
+  // Object.create(null) on both: the keys are value names of the survey, and a name like "toString"
+  // read back off Object.prototype would be reported as a record this recorder never made.
+  private cleared: { [name: string]: { stepIndex: number, question: any } } = Object.create(null);
+  private reportedClears: { [key: string]: boolean } = Object.create(null);
   private triggerFunc: (sender: any, options: any) => void;
   private valueFunc: (sender: any, options: any) => void;
   constructor(private context: ISurveyTestContext) {

--- a/packages/survey-core/src/tester/test-runner.ts
+++ b/packages/survey-core/src/tester/test-runner.ts
@@ -619,13 +619,13 @@ export class SurveyTestRunner {
   // Merged per name and per url, exactly like the variables below: a test that overrides one entry
   // keeps the rest of the suite's.
   private resolveFunctions(test: ISurveyTest): { [name: string]: any } {
-    const res: { [name: string]: any } = {};
+    const res: { [name: string]: any } = Object.create(null);
     this.copyByPresence(res, !!this.tests ? this.tests.functions : undefined);
     this.copyByPresence(res, !!test ? test.functions : undefined);
     return res;
   }
   private resolveWeb(test: ISurveyTest): { [url: string]: any } {
-    const res: { [url: string]: any } = {};
+    const res: { [url: string]: any } = Object.create(null);
     this.copyByPresence(res, !!this.tests ? this.tests.web : undefined);
     this.copyByPresence(res, !!test ? test.web : undefined);
     return res;
@@ -654,18 +654,26 @@ export class SurveyTestRunner {
   // Merged per variable name: a test that overrides one root variable keeps the others. A test can
   // override a root variable but cannot remove one - null sets it to null, it does not unset it.
   private resolveVariables(test: ISurveyTest): { [name: string]: any } {
-    const res: { [name: string]: any } = {};
+    const res: { [name: string]: any } = Object.create(null);
     this.copyByPresence(res, !!this.tests ? this.tests.variables : undefined);
     this.copyByPresence(res, !!test ? test.variables : undefined);
     return res;
   }
+  // Cloned and not aliased, for the same reason cloneStart clones the start data: a suite entry is
+  // shared by every test of the run and it belongs to the caller, so a value one test mutates must
+  // not reach the next one - or the document the caller passed in. Only plain objects and arrays go
+  // through the JSON clone; a Date or an instance of a class is copied as it is.
   private copyByPresence(dest: any, source: any): void {
     if (!this.isObject(source)) return;
     Object.keys(source).forEach(key => {
       if (Object.prototype.hasOwnProperty.call(source, key)) {
-        dest[key] = source[key];
+        dest[key] = this.cloneValue(source[key]);
       }
     });
+  }
+  private cloneValue(val: any): any {
+    const isPlain = Array.isArray(val) || (!!val && typeof val === "object" && val.constructor === Object);
+    return isPlain ? this.cloneJson(val) : val;
   }
   private getDefinition(): any {
     const survey = this.surveyJson;

--- a/packages/survey-core/src/tester/test-stubs.ts
+++ b/packages/survey-core/src/tester/test-stubs.ts
@@ -35,7 +35,9 @@ interface IInstalledFunction {
   // it because another one finished.
   count: number;
 }
-const installedFunctions: { [name: string]: IInstalledFunction } = {};
+// Object.create(null) and not {}: the keys are function names a case writes, and a name like
+// "toString" read back off Object.prototype would look like a registration nobody made.
+const installedFunctions: { [name: string]: IInstalledFunction } = Object.create(null);
 
 // One entry per name, whatever the number of runs: the dispatcher is stateless and routes by survey.
 function createFunctionDispatcher(name: string): (params: any[], originalParams: any[]) => any {
@@ -119,7 +121,10 @@ export type SurveyTestStubReporter = (code: string, message: string, data?: any)
 
 export class SurveyTestStubs {
   private reporter: SurveyTestStubReporter;
-  private timers: Array<any> = [];
+  // Answers that were scheduled and have not been given yet. They are not dropped on teardown: a
+  // choicesByUrl request is "running" from the moment it was sent until it answers, so a dropped
+  // answer leaves the question loading for as long as the model the host was handed lives.
+  private pending: Array<{ run: () => void }> = [];
   private installedNames: Array<string> = [];
   private isDisposedValue: boolean = false;
   private webProviderValue: ISurveyWebProvider;
@@ -161,13 +166,15 @@ export class SurveyTestStubs {
     stubsBySurvey.set(survey, this);
     survey.webProvider = this.webProvider;
   }
-  // Everything this test started stops here: a pending answer is dropped instead of landing on a model
-  // no step is watching, and the names this test holds go back to what they were.
+  // Everything this test started stops here: what was scheduled and never answered is answered now,
+  // at once, and the names this test holds go back to what they were. isDisposedValue is set first,
+  // so the answers land on the model without reporting anything - there is no step left to report to.
   public dispose(): void {
     if (this.isDisposedValue) return;
     this.isDisposedValue = true;
-    this.timers.forEach(timer => clearTimeout(timer));
-    this.timers = [];
+    const pending = this.pending;
+    this.pending = [];
+    pending.forEach(entry => entry.run());
     this.installedNames.forEach(name => uninstallFunction(name));
     this.installedNames = [];
     this.reporter = undefined;
@@ -180,11 +187,18 @@ export class SurveyTestStubs {
     if (!!stub) return stub;
     // A code handler serves what the case did not declare: the case document is the reproducible
     // artifact, so a JSON entry always wins.
-    return !!this.functionHandlers && !!this.functionHandlers[name] ? {} : undefined;
+    return !!this.getFunctionHandler(name) ? {} : undefined;
+  }
+  // The handler map comes from the application as it wrote it, so a name that is a member of
+  // Object.prototype - "toString", "constructor" - must not read back as a handler it never supplied.
+  private getFunctionHandler(name: string): SurveyTestFunction {
+    const handlers = this.functionHandlers;
+    if (!handlers || !Object.prototype.hasOwnProperty.call(handlers, name)) return undefined;
+    return handlers[name];
   }
   public runFunctionStub(name: string, stub: ISurveyTestFunctionStub, params: any[], properties: any): any {
     const isAsync = this.isAsyncStub(name);
-    const handler = !!this.functionHandlers ? this.functionHandlers[name] : undefined;
+    const handler = this.getFunctionHandler(name);
     if (!!handler && !this.functions[name]) {
       return this.runFunctionHandler(name, handler, params, properties, isAsync);
     }
@@ -282,22 +296,16 @@ export class SurveyTestStubs {
     // a host that keeps rendering the model reloads a url. Such a request was never part of the test:
     // no step waits for it and nothing is reported about it, but a url this test claims still has to
     // be answered. Dropping it would leave the question loading for as long as the model lives.
-    const afterTeardown = this.isDisposedValue;
+    // schedule() gives the answer at once once this object is disposed, for that very reason.
     const stub = this.web[url];
     if (!!stub) {
-      // A delay describes a slow service to the step that waits for it. After teardown no step does,
-      // and this object no longer owns timers: it is the same answer, given at once.
-      if (afterTeardown) {
-        onResponse(this.getWebStubResponse(stub));
-        return;
-      }
       this.schedule(() => {
         onResponse(this.getWebStubResponse(stub));
       }, stub.delay);
       return;
     }
     if (!!this.webHandler) {
-      this.runWebHandler(url, onResponse, afterTeardown);
+      this.runWebHandler(url, onResponse);
       return;
     }
     this.reportUnstubbedUrl(url);
@@ -310,8 +318,7 @@ export class SurveyTestStubs {
       response: stub.response,
     };
   }
-  private runWebHandler(url: string, onResponse: (response: ISurveyWebResponse) => void,
-    afterTeardown?: boolean): void {
+  private runWebHandler(url: string, onResponse: (response: ISurveyWebResponse) => void): void {
     const request: ISurveyTestWebHandlerRequest = { url: url };
     let res: any = undefined;
     try {
@@ -322,14 +329,12 @@ export class SurveyTestStubs {
       return;
     }
     if (!!res && typeof res.then === "function") {
-      // An answer to a request the test made is dropped once the test is over: it would land on a
-      // model no step is watching. An answer to a request that came after teardown is the only thing
-      // whoever made that request is waiting for.
+      // Answered whenever it resolves, teardown or not: the question that sent the request is loading
+      // until it hears back, and nobody else is going to tell it. Anything the answer wants to report
+      // is dropped instead - report() is a no-op once this object is disposed.
       res.then((response: ISurveyWebResponse) => {
-        if (this.isDisposedValue && !afterTeardown) return;
         onResponse(this.toWebResponse(url, response));
       }, (error: any) => {
-        if (this.isDisposedValue && !afterTeardown) return;
         this.reportWebHandlerError(url, error);
         onResponse({ status: 200, response: [] });
       });
@@ -370,21 +375,28 @@ export class SurveyTestStubs {
   // slow handler, not a different date. Zero costs no timer - a microtask is already a turn later than
   // the call that started it, which is all "asynchronous" has to mean here.
   private schedule(action: () => void, delay?: number): void {
-    if (this.isDisposedValue) return;
-    const ms = typeof delay === "number" && isFinite(delay) && delay > 0 ? delay : 0;
-    if (ms === 0) {
-      Promise.resolve().then(() => {
-        if (this.isDisposedValue) return;
-        action();
-      });
+    // After teardown there is no step to simulate a slow service for, and the answer is still the only
+    // thing whoever sent the request is waiting for: give it at once.
+    if (this.isDisposedValue) {
+      action();
       return;
     }
-    const timer = setTimeout(() => {
-      this.timers = this.timers.filter(item => item !== timer);
-      if (this.isDisposedValue) return;
+    const ms = typeof delay === "number" && isFinite(delay) && delay > 0 ? delay : 0;
+    let timer: any = undefined;
+    let isDone = false;
+    const entry = { run: (): void => {
+      if (isDone) return;
+      isDone = true;
+      if (timer !== undefined) clearTimeout(timer);
+      this.pending = this.pending.filter(item => item !== entry);
       action();
-    }, ms);
-    this.timers.push(timer);
+    } };
+    this.pending.push(entry);
+    if (ms === 0) {
+      Promise.resolve().then(() => entry.run());
+    } else {
+      timer = setTimeout(() => entry.run(), ms);
+    }
   }
   private report(code: string, message: string, data?: any): void {
     if (!this.reporter || this.isDisposedValue) return;

--- a/packages/survey-core/src/tester/test-validator.ts
+++ b/packages/survey-core/src/tester/test-validator.ts
@@ -32,7 +32,9 @@ export class SurveyTestValidator {
         "A test suite must contain a non-empty \"tests\" array.");
       return issues;
     }
-    const nameIndexes: { [name: string]: number } = {};
+    // Object.create(null): a suite names its tests and its starts, and a name like "constructor"
+    // read back off Object.prototype would look like an entry that was already registered.
+    const nameIndexes: { [name: string]: number } = Object.create(null);
     for (let i = 0; i < testsArray.length; i++) {
       const test = testsArray[i];
       const path = "tests[" + i + "]";
@@ -306,7 +308,9 @@ export class SurveyTestValidator {
       this.addIssue(issues, SurveyTestIssueCodes.startsNotAnArray, "\"starts\" must be an array.", { path: "starts" });
       return names;
     }
-    const nameIndexes: { [name: string]: number } = {};
+    // Object.create(null): a suite names its tests and its starts, and a name like "constructor"
+    // read back off Object.prototype would look like an entry that was already registered.
+    const nameIndexes: { [name: string]: number } = Object.create(null);
     for (let i = 0; i < starts.length; i++) {
       const start: any = starts[i];
       const path = "starts[" + i + "]";

--- a/packages/survey-core/tests/tester/testChecksTests.ts
+++ b/packages/survey-core/tests/tester/testChecksTests.ts
@@ -972,3 +972,63 @@ describe("A custom check", () => {
     expect(outcome < 0, "and is listed nowhere").toBeTruthy();
   });
 });
+
+// getAllErrors() and not "errors": a matrix, a dynamic panel and a multipletext keep the errors of
+// their cells, panels and items in the children, and reading "errors" made the question checks say
+// there was nothing wrong while the survey check of the same run counted the error.
+describe("SurveyTestChecks: errors of a question whose children carry them", () => {
+  const requiredCell = {
+    elements: [{
+      type: "matrixdynamic", name: "m", rowCount: 1,
+      columns: [{ name: "a", cellType: "text", isRequired: true }],
+    }],
+  };
+  test("hasErrors, errorCount and errors include the errors of the cells", async () => {
+    const outcome = await runExpect(requiredCell, {
+      survey: { errorCount: 1 },
+      m: { hasErrors: true, errorCount: 1 },
+    }, { before: [{ complete: { survey: true } }] });
+    outcome.checks.forEach(check => {
+      expect(check.passed, "the check \"" + check.check + "\" of \"" + check.target +
+        "\" agrees with the survey; message: " + check.message).toBeTruthy();
+    });
+    const errors = await runCheck(requiredCell, "m", "errorCount", 1,
+      { before: [{ complete: { survey: true } }] });
+    expect(errors.actual).toEqual(1);
+  });
+});
+
+// A check handler is registered code and a registration written in untyped JavaScript can throw or
+// answer with nothing. Either way it is that one pair that failed: the pairs after it still run.
+describe("SurveyTestChecks: a handler that misbehaves", () => {
+  const oneQuestion = { elements: [{ type: "text", name: "q1" }] };
+  afterEach(() => {
+    SurveyTestCheckFactory.Instance.unregister("brokenCheck");
+  });
+  function runWithBrokenCheck(): Promise<IRunOutcome> {
+    // The broken check comes first, so the sibling after it is the one that must still run.
+    return runExpect(oneQuestion, { q1: { brokenCheck: true, value: "a" } },
+      { before: [{ set: { q1: "a" } }] });
+  }
+  test("A check that returns nothing is reported and the siblings still run", async () => {
+    SurveyTestCheckFactory.Instance.register({
+      name: "brokenCheck", payloadType: "boolean", kinds: ["question"],
+      check: (): any => undefined,
+    });
+    const outcome = await runWithBrokenCheck();
+    expect(outcome.codes).toEqual([SurveyTestIssueCodes.unexpectedError]);
+    expect(outcome.messages.indexOf("brokenCheck") > -1, "the message names the check").toBeTruthy();
+    expect(outcome.checks.map(check => check.check), "the sibling produced its result").toEqual(["value"]);
+  });
+  test("A check that throws is reported and the siblings still run", async () => {
+    SurveyTestCheckFactory.Instance.register({
+      name: "brokenCheck", payloadType: "boolean", kinds: ["question"],
+      check: (): any => { throw new Error("the check gave up"); },
+    });
+    const outcome = await runWithBrokenCheck();
+    expect(outcome.codes).toEqual([SurveyTestIssueCodes.unexpectedError]);
+    expect(outcome.messages.indexOf("brokenCheck") > -1, "the message names the check").toBeTruthy();
+    expect(outcome.messages.indexOf("the check gave up") > -1, "and keeps what it threw").toBeTruthy();
+    expect(outcome.checks.map(check => check.check), "the sibling produced its result").toEqual(["value"]);
+  });
+});

--- a/packages/survey-core/tests/tester/testCommandsTests.ts
+++ b/packages/survey-core/tests/tester/testCommandsTests.ts
@@ -525,3 +525,64 @@ describe("A command that throws never escapes run()", () => {
     }
   });
 });
+
+// A matrixdynamic whose rows are filtered by "rowsVisibleIf": the value of the question is indexed by
+// the generated rows, so the visible ones are a different list and indexing it would silently move a
+// value into the wrong row and drop the last one.
+describe("SurveyTestRunner: setting the value of a matrix with hidden rows", () => {
+  const hiddenRowMatrix = {
+    elements: [{
+      type: "matrixdynamic", name: "m", rowCount: 3,
+      rowsVisibleIf: "{row.a} <> 'skip'",
+      columns: [{ name: "a", cellType: "text" }],
+    }],
+  };
+  test("Every value lands in the row its index names", async () => {
+    const outcome = await runSteps(hiddenRowMatrix, [
+      { setDirectly: { m: [{ a: "keep" }, {}, {}] } },
+      { set: { m: [{ a: "1" }, { a: "2" }, { a: "3" }] } },
+    ]);
+    expect(outcome.codes, "nothing is reported: " + outcome.messages).toEqual([]);
+    expect(question(outcome, "m").value, "the rows keep the order of the value")
+      .toEqual([{ a: "1" }, { a: "2" }, { a: "3" }]);
+  });
+  test("A hidden row is refused instead of shifting the values into the wrong rows", async () => {
+    const outcome = await runSteps(hiddenRowMatrix, [
+      { setDirectly: { m: [{ a: "skip" }, {}, {}] } },
+      { set: { m: [{ a: "1" }, { a: "2" }, { a: "3" }] } },
+    ]);
+    expect(outcome.codes, "a respondent cannot fill in a hidden row")
+      .toEqual([SurveyTestIssueCodes.valueNotEnterable]);
+    expect(outcome.messages.indexOf("m[0]") > -1, "the message names the row").toBeTruthy();
+    expect(outcome.messages.indexOf("rowsVisibleIf") > -1, "and says what hides it").toBeTruthy();
+  });
+});
+
+// A step key that is a member of Object.prototype must reach the command registry as the unknown name
+// it is, and not read back as a function that lives on every object literal.
+describe("SurveyTestRunner: a command named after an Object.prototype member", () => {
+  test("A step key \"toString\" is an unknown command", async () => {
+    const outcome = await runSteps(twoQuestions, [<any>{ toString: { q1: "x" } }]);
+    expect(outcome.codes).toEqual([SurveyTestIssueCodes.unknownCommand]);
+  });
+});
+
+// A choice with "showCommentArea" is selected as { value, comment }: that is the form the model
+// produces and stores, so it is the form a case writes to select such a choice.
+describe("SurveyTestRunner: selecting a choice that carries a comment", () => {
+  const choiceComment = {
+    elements: [{
+      type: "radiogroup", name: "q1",
+      choices: [{ value: "a", showCommentArea: true }, "b"],
+    }],
+  };
+  test("The comment travels with the value and only the value is matched against the choices", async () => {
+    const outcome = await runSteps(choiceComment, [{ set: { q1: { value: "a", comment: "hello" } } }]);
+    expect(outcome.codes, "the value is a choice: " + outcome.messages).toEqual([]);
+    expect(question(outcome, "q1").value).toEqual({ value: "a", comment: "hello" });
+  });
+  test("A value that is not a choice is still refused in that form", async () => {
+    const outcome = await runSteps(choiceComment, [{ set: { q1: { value: "zzz", comment: "hello" } } }]);
+    expect(outcome.codes).toEqual([SurveyTestIssueCodes.invalidChoiceValue]);
+  });
+});

--- a/packages/survey-core/tests/tester/testDiagnosticsTests.ts
+++ b/packages/survey-core/tests/tester/testDiagnosticsTests.ts
@@ -640,3 +640,44 @@ describe("The renderings in issue #11692", () => {
     expect(issue.data.clearInvisibleValues).toEqual("onComplete");
   });
 });
+
+// The trace of a failed check reads the expression, it does not run it. Running one that calls a
+// function would call that function a second time: the stub dispatcher routes by survey and its cache
+// is off on purpose, so a stub that reports a failure would report it twice and a handler the
+// application supplied would run twice - from a step that performs no command at all.
+describe("Expression traces never re-run what they explain", () => {
+  const stubbedExpression = {
+    elements: [
+      { type: "text", name: "trigger" },
+      { type: "text", name: "q1", visibleIf: "boom() = 1" },
+    ],
+  };
+  test("A step that only checks produces no issue of the stub's own", async () => {
+    const result = await new SurveyTestRunner(stubbedExpression, {
+      functions: { boom: { async: false, error: "handler exploded" } },
+      tests: [{
+        name: "trace",
+        steps: [
+          { name: "act", set: { trigger: "x" } },
+          { name: "check", expect: { q1: { visible: true } } },
+        ],
+      }],
+    }).run();
+    const steps = result.tests[0].steps;
+    expect(steps[0].issues.map(issue => issue.code), "the command called the stub")
+      .toEqual([SurveyTestIssueCodes.functionStubFailed]);
+    expect(steps[1].issues.map(issue => issue.code), "the check did not call it again").toEqual([]);
+  });
+  test("The trace of an expression that calls a function reports the values without a result", () => {
+    const survey = new SurveyModel({
+      elements: [
+        { type: "text", name: "q1" },
+        { type: "text", name: "q2", visibleIf: "someFunc({q1}) = 1" },
+      ],
+    });
+    survey.setValue("q1", "a");
+    const trace = getExpressionTrace(survey.getQuestionByName("q2"), "someFunc({q1}) = 1");
+    expect(trace.values, "the values it reads are still reported").toEqual({ q1: "a" });
+    expect(trace.result, "and the result is not computed by running it").toBeUndefined();
+  });
+});

--- a/packages/survey-core/tests/tester/testJsonValidatorTests.ts
+++ b/packages/survey-core/tests/tester/testJsonValidatorTests.ts
@@ -484,3 +484,26 @@ describe("SurveyTestValidator: the public methods and the state", () => {
     });
   });
 });
+
+// The name maps of the validator are keyed by names the case writes. A name that is a member of
+// Object.prototype must not read back as an entry that was already registered.
+describe("SurveyTestValidator: names that collide with Object.prototype members", () => {
+  test("A test named \"constructor\" is not a duplicate of itself", () => {
+    const tests: ISurveyTests = { tests: [{ name: "constructor", steps: [{ expect: { q1: { value: 1 } } }] }] };
+    expect(codes(validate(tests))).toEqual([]);
+  });
+  test("A \"starts\" entry named \"toString\" is a normal start", () => {
+    const tests: ISurveyTests = {
+      starts: [{ name: "toString", data: { q1: 1 } }],
+      tests: [{ name: "t", start: "toString", steps: [{ expect: { q1: { value: 1 } } }] }],
+    };
+    expect(codes(validate(tests))).toEqual([]);
+  });
+  test("Two entries that really share such a name are still duplicates", () => {
+    const tests: ISurveyTests = {
+      starts: [{ name: "constructor", data: { q1: 1 } }, { name: "constructor", data: { q1: 2 } }],
+      tests: [{ name: "t", start: "constructor", steps: [{ expect: { q1: { value: 1 } } }] }],
+    };
+    expect(codes(validate(tests))).toEqual([SurveyTestIssueCodes.duplicateStartName]);
+  });
+});

--- a/packages/survey-core/tests/tester/testRunnerTests.ts
+++ b/packages/survey-core/tests/tester/testRunnerTests.ts
@@ -785,3 +785,43 @@ describe("SurveyTestRunner: a single test", () => {
     expect(codes(result.issues), "the missing survey is the only issue").toEqual([SurveyTestIssueCodes.surveyMissing]);
   });
 });
+
+// A suite entry belongs to the caller and is shared by every test of the run, so what the runner hands
+// the model is a copy of it. Aliasing it lets one test change what the next one starts from, and
+// leaves the change in the document the caller passed in.
+describe("SurveyTestRunner: object values of the suite are cloned per test", () => {
+  const oneQuestion = { elements: [{ type: "text", name: "q1" }] };
+  function captureModels(models: Array<SurveyModel>): any {
+    return {
+      createSurvey: (surveyJson: any, context: any): SurveyModel => {
+        const survey = new SurveyModel();
+        survey.dateProvider = context.dateProvider;
+        context.attachProviders(survey);
+        survey.fromJSON(surveyJson);
+        models.push(survey);
+        return survey;
+      },
+    };
+  }
+  test("a variable is neither the caller's object nor shared between two tests", async () => {
+    const shared = ["a", "b"];
+    const suite = {
+      variables: { picked: shared },
+      tests: [
+        { name: "t1", steps: [{ set: { q1: "x" } }] },
+        { name: "t2", steps: [{ set: { q1: "y" } }] },
+      ],
+    };
+    const models: Array<SurveyModel> = [];
+    await new SurveyTestRunner(oneQuestion, suite).run(captureModels(models));
+    const first = models[0].getVariable("picked");
+    const second = models[1].getVariable("picked");
+    expect(first, "the value is the one the suite declares").toEqual(["a", "b"]);
+    expect(first === shared, "and not the array the caller holds").toBeFalsy();
+    expect(first === second, "and not the array the other test holds").toBeFalsy();
+
+    first.push("LEAKED");
+    expect(shared, "so a mutation stays inside the test that made it").toEqual(["a", "b"]);
+    expect(second).toEqual(["a", "b"]);
+  });
+});

--- a/packages/survey-core/tests/tester/testStubsTests.ts
+++ b/packages/survey-core/tests/tester/testStubsTests.ts
@@ -784,7 +784,7 @@ describe("survey-tester: stubs, cancellation and single tests", () => {
     setTimeout(() => controller.abort(), 5);
     const result = await promise;
     expect(result.status).toBe("canceled");
-    // Nothing rejects or throws after the run is over: the pending answers were dropped.
+    // Nothing rejects or throws after the run is over: the pending answers were given at teardown.
     await new Promise(resolve => setTimeout(resolve, 60));
   });
   test("runTest() installs the stubs of the suite and of the test", async () => {
@@ -865,5 +865,60 @@ describe("survey-tester: stub validation", () => {
     const issues = validator.validate({ tests: [{ name: "t", functions: { f: {} }, steps: [] }] });
     const issue = issues.filter(item => item.code === SurveyTestIssueCodes.functionStubHasNoResult)[0];
     expect(issue.path).toBe("tests[0].functions.f");
+  });
+});
+
+// A choicesByUrl request is "running" from the moment it is sent until it answers, and the model
+// outlives the run. An answer that is still scheduled when the stubs are disposed is therefore given,
+// not dropped: dropping it leaves the question loading for as long as the model the host was handed
+// lives, and survey.getRunningAsyncOperations() reports it forever.
+describe("survey-tester: a web request that is still in flight at teardown", () => {
+  const slowUrl = "https://x/slow-items";
+  const slowJson = {
+    elements: [{ type: "dropdown", name: "q1", choicesByUrl: { url: slowUrl } }],
+  };
+  function captureModel(models: Array<SurveyModel>): ISurveyTestExecutionOptions {
+    return {
+      createSurvey: (surveyJson: any, context: ISurveyTestModelFactoryContext): SurveyModel => {
+        const survey = new SurveyModel();
+        survey.dateProvider = context.dateProvider;
+        context.attachProviders(survey);
+        survey.fromJSON(surveyJson);
+        models.push(survey);
+        return survey;
+      },
+    };
+  }
+  test("the request is answered and the question stops loading", async () => {
+    const models: Array<SurveyModel> = [];
+    const result = await run(slowJson, {
+      options: { asyncTimeout: 20 },
+      web: { [slowUrl]: { response: ["a", "b"], delay: 500 } },
+      tests: [{ name: "slow service", steps: [{ expect: { q1: { visible: true } } }] }],
+    }, captureModel(models));
+    expect(codes(result.tests[0]), "the step gave up waiting")
+      .toEqual([SurveyTestIssueCodes.asyncOperationTimeout]);
+    const question: any = models[0].getQuestionByName("q1");
+    expect(question.choicesByUrl.isRunning, "nothing is left running on the released model").toBe(false);
+    expect(models[0].getRunningAsyncOperations()).toEqual([]);
+  });
+});
+
+// The map of installed function names is process-wide and keyed by names a case writes: a name that
+// is a member of Object.prototype must not read back as a registration another run is holding.
+describe("survey-tester: a function stub named after an Object.prototype member", () => {
+  test("it installs without colliding with a test that does not exist", async () => {
+    const surveyJson = {
+      elements: [
+        { type: "text", name: "q1" },
+        { type: "expression", name: "out", expression: "toString()" },
+      ],
+    };
+    const result = await run(surveyJson, {
+      functions: { toString: { async: false, result: "stubbed" } },
+      tests: [{ name: "t", steps: [{ expect: { out: { value: "stubbed" } } }] }],
+    });
+    expect(codes(result.tests[0])).toEqual([]);
+    expect(failedChecks(result.tests[0])).toEqual([]);
   });
 });

--- a/packages/survey-core/tests/tester/testTargetTests.ts
+++ b/packages/survey-core/tests/tester/testTargetTests.ts
@@ -2,8 +2,8 @@ import { SurveyModel } from "../../src/survey";
 import { ISurveyTestIssue, ISurveyTestsResult, SurveyTestIssueCodes } from "../../src/tester/test-result";
 import { ISurveyTestContext, ISurveyTestTarget, SurveyTestCaseError, SurveyTestContext } from "../../src/tester/test-context";
 import { SurveyTestRunner } from "../../src/tester/test-runner";
-import { SurveyTestCommandFactory } from "../../src/tester/test-commands";
-import { SurveyTestCheckFactory } from "../../src/tester/test-checks";
+import { ISurveyTestCommand, SurveyTestCommandFactory } from "../../src/tester/test-commands";
+import { ISurveyTestCheckHandler, SurveyTestCheckFactory } from "../../src/tester/test-checks";
 
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
@@ -244,10 +244,17 @@ describe("SurveyTestRunner: targets in a case", () => {
   });
 });
 
+// The stand-ins below take the names of two built-ins. The registries are process-wide, so what was
+// registered under those names is put back afterwards - unregistering would delete the built-in for
+// every test file that runs after this one. Same shape as testRunnerTests.ts.
 describe("SurveyTestRunner: the payload is checked before the handler runs", () => {
   let calls: Array<string>;
+  let savedCommand: ISurveyTestCommand;
+  let savedCheck: ISurveyTestCheckHandler;
   beforeEach(() => {
     calls = [];
+    savedCommand = SurveyTestCommandFactory.Instance.get("addRow");
+    savedCheck = SurveyTestCheckFactory.Instance.get("visible");
     SurveyTestCommandFactory.Instance.register({
       name: "addRow",
       payloadType: "number",
@@ -263,8 +270,10 @@ describe("SurveyTestRunner: the payload is checked before the handler runs", () 
     });
   });
   afterEach(() => {
-    SurveyTestCommandFactory.Instance.unregister("addRow");
-    SurveyTestCheckFactory.Instance.unregister("visible");
+    if (!!savedCommand) SurveyTestCommandFactory.Instance.register(savedCommand);
+    else SurveyTestCommandFactory.Instance.unregister("addRow");
+    if (!!savedCheck) SurveyTestCheckFactory.Instance.register(savedCheck);
+    else SurveyTestCheckFactory.Instance.unregister("visible");
   });
   test("A command payload of the wrong type produces invalidCommandParams", async () => {
     const result = await run(targetSurvey, {


### PR DESCRIPTION
…ollution

- Updated various registries in the survey testing framework to use Object.create(null) instead of plain objects. This change prevents potential issues with prototype members being accessed unintentionally, ensuring that only explicitly defined properties are used.
- Enhanced error handling in survey checks to report unexpected outcomes and exceptions more clearly.
- Added tests to verify the behavior of commands and checks when encountering errors or unexpected values, ensuring robustness in the testing framework.
- Improved the handling of dynamic matrix rows and choices with comments, ensuring that values are correctly assigned and validated.