### PR TITLE
Stabilize flaky test 'Check file question mobile mode' from 'file.spec.ts' on branch 'V2'

### DIFF
--- a/screenshots/file.spec.ts
+++ b/screenshots/file.spec.ts
@@ -216,10 +216,22 @@ frameworks.forEach(framework => {
       await page.setInputFiles(".sd-file input", ["../../screenshots/files/Badger.png", "../../screenshots/files/Bird.png", "../../screenshots/files/Read Me.txt", "../../screenshots/files/Flamingo.png"]);
       await page.click(".sd-file input[type=file] + div label");
 
+      // Wait for all 4 files to finish async processing before sorting
+      await page.waitForFunction(() => {
+        const question = (window as any).survey.getQuestionByName("file_question");
+        return question && Array.isArray(question.value) && question.value.length === 4;
+      });
+
       await page.evaluate(() => {
         const order = ["Badger.png", "Bird.png", "Read Me.txt", "Flamingo.png"];
         const question = (window as any).survey.getQuestionByName("file_question");
         question.value = [].concat(question.value).sort((a: any, b: any) => order.indexOf(a.name) - order.indexOf(b.name));
+      });
+
+      // Wait for fileIndexAction to be initialized after the value update
+      await page.waitForFunction(() => {
+        const question = (window as any).survey.getQuestionByName("file_question");
+        return !!(question && question.fileIndexAction);
       });
 
       await page.evaluate(() => {


### PR DESCRIPTION
Automated flaky-test stabilization by Claude Code (headless).

Branch: V2
Target test: screenshots/file.spec.ts::react File Screenshot › Check file question mobile mode::vrt

---

=== AI FIX REPORT ===
model: claude-sonnet-4-6
subtype: success
is_error: false
num_turns: 10
duration_ms: 176396
cost_usd: 0.35096250000000007

The fix is clean, correct, and all 5 repeated runs pass.

---

## PR Summary

### Target test
`screenshots/file.spec.ts :: react File Screenshot › Check file question mobile mode :: vrt`

### Root cause — TEST FLAKINESS (timing race)

After calling `page.click(".sd-file input[type=file] + div label")` to trigger the file-upload callback, SurveyJS processes the selected files **asynchronously** (reads each file's content as base64, then sets `question.value`). The test immediately fired two `page.evaluate()` calls without waiting for that async work to finish:

1. **Sort evaluate** — executed while files were still being read; `question.value` contained fewer than 4 items (sometimes 0 or 1), making the sort meaningless.
2. **`fileIndexAction` evaluate** — tried to set `question.fileIndexAction.title`, but `fileIndexAction` is only created once the file question has actual values to paginate in mobile mode. With an incomplete value it was `undefined`, producing:
   ```
   TypeError: Cannot set properties of undefined (setting 'title')
   ```

### Fix

Added two `page.waitForFunction()` guards (web-first polling, no hard timeouts):

1. **Before sorting**: wait until `question.value.length === 4` — ensures all files have been fully processed before the sort runs.
2. **Before accessing `fileIndexAction`**: wait until `question.fileIndexAction` is truthy — ensures the mobile navigation action has been initialized after the value is set.

### Files changed
- `screenshots/file.spec.ts`
