### PR TITLE
feat(linter): enhance expression validation with new rules and reasons

### DIFF
--- a/packages/survey-core/src/linter/README.md
+++ b/packages/survey-core/src/linter/README.md
@@ -43,6 +43,9 @@ linting and no configuration is needed.
 | `lintSurvey(json, options?): ISurveyLintResult` | Runs every enabled rule over the survey JSON. |
 | `getRules(): Array<ILintRuleInfo>` | The rule registry: `{ id, defaultSeverity }` per rule. |
 | `renderFindings(result \| findings, options?): string` | Human-readable text report (`{ includeSuppressed?: boolean }`). |
+| `SurveyLintReasons` | `reason` values per rule id — the localization key, see [Localization](#localization). |
+| `SurveyLintHintReasons` | `hint.reason` values. |
+| `SurveyLintReproductionReasons` | `reproduction.reason` values. |
 
 ### Result
 
@@ -59,8 +62,10 @@ interface ISurveyLintResult {
 interface ILintFinding {
   ruleId: string;
   severity: "error" | "warning" | "info";
-  message: string;                     // ready to show to a human
+  message: string;                     // ready to show to a human, in English
+  reason?: string;                     // which branch of the rule's message this is
   messageData: { [key: string]: any }; // the same facts, structured, for custom formatting
+  hint?: { reason: string, name: string };  // the scope hint appended to the message
   path: string;                        // "pages[0].elements[1].visibleIf"
   elementName?: string;
   elementType?: string;
@@ -69,6 +74,40 @@ interface ILintFinding {
   reproduction?: ILintReproduction;    // steps demonstrating the defect: { set } / { expect }
 }
 ```
+
+## Localization
+
+`message` is English. A host that shows findings in its own language does not translate that
+string: it composes its own sentence from **`(ruleId, reason)`** plus `messageData`.
+
+`reason` names the branch of the rule's message the finding took, and every value is listed in
+`SurveyLintReasons[ruleId]`. **The rule ids and the reason values are public API — they are
+frozen and they stay stable.** `getRules()` gives the rule ids on their own, for a host that
+also names the checks.
+
+```js
+import { lintSurvey, SurveyLintReasons } from "survey-core/linter";
+
+const key = finding.ruleId + "/" + finding.reason;   // "reference/unknown/notFound"
+const text = format(myStrings[key], finding.messageData);
+```
+
+Three things are composed on top of the base sentence, and none of them needs a channel of its
+own — a host appends them from fields it already has:
+
+* `finding.suggestion` — the *Did you mean "x"?* clause.
+* `messageData.expression` — the *(in "…")* clause.
+* `messageData.refKind` — for `reference/unknown`, whether the reference came from `bindings`
+  or from a `choicesByUrl` URL.
+
+`finding.hint` is the one part that is not a branch: any base message of `reference/unknown` can
+carry any of the `SurveyLintHintReasons`, so it travels separately. `reproduction.reason` and
+`messageData.suggestionReason` (`expression/type-mismatch` only, whose `suggestion` is prose
+rather than an identifier) work the same way.
+
+A rule interpolates only what it also reports in `messageData`, so a localized message never
+needs a fact the finding does not carry. `tests/linter/linter-reasons.tests.ts` pins that: every
+reason in the table is reachable, and every finding carries one.
 
 ### Options
 
@@ -109,7 +148,9 @@ interface ISurveyLintOptions {
 | `choices/dead-source` | error | `choicesFromQuestion` pointing at a missing question, at itself, or at a question that provides neither choices nor an array of values; `choiceValuesFromQuestion`/`choiceTextsFromQuestion` naming a column or template question that does not exist. |
 | `trigger/unknown-target` | error | `setToName`, `fromName`, `gotoName` or `runExpression` targets that do not exist. |
 | `trigger/unknown-type` | warning | A missing or unknown trigger `type` (silently dropped at runtime). |
-| `page/empty` | warning | A page or panel with no element that can ever render, and a dynamic panel with an empty template. |
+| `expression/contradiction` | warning | A condition that can never hold. Today the decidable part of it: a condition built entirely from constants that evaluates to false. |
+| `expression/meaningless-condition` | warning | A condition whose result is known upfront in some other way - always true, arithmetic where a boolean is expected, or a fragment (a constant branch of `and`/`or`, a comparison of two constants, an operand compared with itself). |
+| `page/empty` | warning | A page or panel with no element that can ever render, and a dynamic panel with an empty template. An element is counted out when it is statically hidden or its own `visibleIf` can never hold. |
 
 ## What the analysis understands
 
@@ -132,10 +173,28 @@ interface ISurveyLintOptions {
   analysed without touching this folder. `catalog.ts` holds only the handful of semantics the
   metadata cannot carry, and `tests/linter/linter-catalog-drift.tests.ts` guards it.
 
+## Relation to `Base.validateExpressions`
+
+`validateExpressions` reports four kinds of error over a **built model**. The linter reports the
+same four over the **authored JSON**: syntax errors as `expression/syntax`, unknown functions as
+`expression/unknown-function`, unknown variables as `reference/unknown`, and semantic errors as
+`expression/contradiction` (the condition is always false) or `expression/meaningless-condition`
+(everything else). The semantic verdict is taken from the core itself — the rules call
+`Operand.addConditionSemanticErrors` rather than reimplementing it — so the two stay in step,
+including the deliberate silence on a lone boolean constant: `visibleIf: "false"` is how an author
+switches an element off, not a defect, and nothing reports it.
+
+`expression/contradiction` is the first instalment of the reachability group of #11693. It is
+named for the whole defect, so the satisfiability reasoning that group asks for extends this rule
+later instead of needing a new id.
+
 ## Limits
 
 * No runtime data: a defect that appears only for a particular set of answers is out of scope,
   and conditions are not solved (a `cycle/trigger` loop may be unreachable — the message says so).
+  A condition made **only** of constants is the exception: it has no answers to depend on, so it
+  is evaluated. `{q} = 'a' and {q} = 'b'` is a contradiction that needs satisfiability and is not
+  reported yet.
 * A custom question type without a `components` entry is analysed as an opaque element.
 * A custom trigger type is not covered by the target and cycle checks.
 
@@ -183,6 +242,7 @@ WARN  expression/unknown-choice
 | `value-types.ts` | Per-question value shape and choice information. |
 | `graph.ts`, `levenshtein.ts` | Cycle detection and typo suggestions. |
 | `rule.ts` | `ILintRule`, `LintContext.report`, severity resolution and suppression matching. |
+| `reasons.ts` | The frozen `(ruleId, reason)` tables a host localizes on. |
 | `rules/` | One file per rule, registered in `rules/index.ts`. |
 | `renderer.ts` | `renderFindings` — the text report. |
 
@@ -196,7 +256,10 @@ WARN  expression/unknown-choice
 3. Give every finding a `path`, a message a form author can act on, and the same facts in
    `messageData`; add a `suggestion` when the defect looks like a typo and a `reproduction`
    when the failure can be demonstrated with a few `set` steps.
-4. Add tests under `tests/linter/`.
+4. Add an entry for the rule to `SurveyLintReasons` in `reasons.ts`, with one value per branch
+   of its message, and pass it as `reason`. Interpolate nothing the finding does not also
+   report: a host composes the localized sentence from `(ruleId, reason)` and `messageData`.
+5. Add tests under `tests/linter/`.
 
 ## Build and test
 

--- a/packages/survey-core/src/linter/expression-utils.ts
+++ b/packages/survey-core/src/linter/expression-utils.ts
@@ -1,5 +1,6 @@
 import { ArrayOperand, BinaryOperand, ConditionsParser, Const, FunctionOperand, getBuiltInVariableNames, Operand, ValueGetter, Variable } from "survey-core";
 import { ISurveyLintOptions, LintReproductionStep } from "./types";
+import { SurveyLintHintReasons } from "./reasons";
 import { ILintResolvedSettings } from "./lint-settings";
 import { closestMatch } from "./levenshtein";
 import {
@@ -134,6 +135,13 @@ interface ScopeResolution {
   ref?: ParsedRef;
   // set when the root word looks like a scope prefix but the scope is not active
   inactiveHint?: string;
+  inactiveHintReason?: string;
+  inactiveHintName?: string;
+}
+
+// The text is what the English message shows; the reason is what a host localizes on.
+function inactiveScope(reason: string, name: string, text: string): ScopeResolution {
+  return { handled: false, inactiveHint: text, inactiveHintReason: reason, inactiveHintName: name };
 }
 
 function scopedResolved(ref: ParsedRef, prefix: string): ParsedRef {
@@ -190,14 +198,16 @@ function tryResolveScopePrefix(ref: ParsedRef, site: { owner?: ElementRecord, sc
   const rowPrefixes = [vars.row, vars.prevRow, vars.nextRow, vars.totalRow];
   for (let i = 0; i < rowPrefixes.length; i++) {
     if (equalsCI(root, rowPrefixes[i])) {
-      if (!matrixFrame) return { handled: false, inactiveHint: "\"" + rowPrefixes[i] + ".\" references are only available inside a matrix cell or a matrix detail panel." };
+      if (!matrixFrame) return inactiveScope(SurveyLintHintReasons.rowScopePrefix, rowPrefixes[i],
+        "\"" + rowPrefixes[i] + ".\" references are only available inside a matrix cell or a matrix detail panel.");
       return { handled: true, ref: validateInnerName(ref, rowPrefixes[i], matrixFrame.columns, lintSettings) };
     }
   }
   const rowStandalone = [vars.rowIndex, vars.visibleRowIndex, vars.rowValue, vars.rowName, vars.rowTitle, vars.matrix];
   for (let i = 0; i < rowStandalone.length; i++) {
     if (equalsCI(root, rowStandalone[i])) {
-      if (!matrixFrame) return { handled: false, inactiveHint: "\"" + rowStandalone[i] + "\" is only available inside a matrix cell or a matrix detail panel." };
+      if (!matrixFrame) return inactiveScope(SurveyLintHintReasons.rowScopeStandalone, rowStandalone[i],
+        "\"" + rowStandalone[i] + "\" is only available inside a matrix cell or a matrix detail panel.");
       return { handled: true, ref: scopedResolved(ref, rowStandalone[i]) };
     }
   }
@@ -216,31 +226,36 @@ function tryResolveScopePrefix(ref: ParsedRef, site: { owner?: ElementRecord, sc
       }
       return { handled: true, ref: scopedUnknown(ref, vars.panel, 1, staticPanel.panelDescendantNames.names()) };
     }
-    return { handled: false, inactiveHint: "\"" + vars.panel + ".\" references are only available inside a dynamic panel or a panel container." };
+    return inactiveScope(SurveyLintHintReasons.panelScopePrefix, vars.panel,
+      "\"" + vars.panel + ".\" references are only available inside a dynamic panel or a panel container.");
   }
   const panelSiblings = [vars.prevPanel, vars.nextPanel];
   for (let i = 0; i < panelSiblings.length; i++) {
     if (equalsCI(root, panelSiblings[i])) {
-      if (!panelFrame) return { handled: false, inactiveHint: "\"" + panelSiblings[i] + ".\" references are only available inside a dynamic panel." };
+      if (!panelFrame) return inactiveScope(SurveyLintHintReasons.panelSiblingPrefix, panelSiblings[i],
+        "\"" + panelSiblings[i] + ".\" references are only available inside a dynamic panel.");
       return { handled: true, ref: validateInnerName(ref, panelSiblings[i], panelFrame.templateNames, lintSettings) };
     }
   }
   const panelStandalone = [vars.parentPanel, vars.panelIndex, vars.visiblePanelIndex];
   for (let i = 0; i < panelStandalone.length; i++) {
     if (equalsCI(root, panelStandalone[i])) {
-      if (!panelFrame) return { handled: false, inactiveHint: "\"" + panelStandalone[i] + "\" is only available inside a dynamic panel." };
+      if (!panelFrame) return inactiveScope(SurveyLintHintReasons.panelStandalone, panelStandalone[i],
+        "\"" + panelStandalone[i] + "\" is only available inside a dynamic panel.");
       return { handled: true, ref: scopedResolved(ref, panelStandalone[i]) };
     }
   }
   const itemPrefixes = [vars.item, vars.choice, vars.column];
   for (let i = 0; i < itemPrefixes.length; i++) {
     if (equalsCI(root, itemPrefixes[i])) {
-      if (!itemFrame) return { handled: false, inactiveHint: "\"" + itemPrefixes[i] + "\" is only available inside choice/row/column conditions." };
+      if (!itemFrame) return inactiveScope(SurveyLintHintReasons.itemScope, itemPrefixes[i],
+        "\"" + itemPrefixes[i] + "\" is only available inside choice/row/column conditions.");
       return { handled: true, ref: scopedResolved(ref, itemPrefixes[i]) };
     }
   }
   if (equalsCI(root, vars.composite)) {
-    if (!compositeFrame) return { handled: false, inactiveHint: "\"" + vars.composite + ".\" references are only available inside a composite question." };
+    if (!compositeFrame) return inactiveScope(SurveyLintHintReasons.compositeScopePrefix, vars.composite,
+      "\"" + vars.composite + ".\" references are only available inside a composite question.");
     if (compositeFrame.fieldNames.size === 0 || ref.segments.length < 2) {
       return { handled: true, ref: scopedResolved(ref, vars.composite) };
     }
@@ -458,16 +473,24 @@ function classifyRefCore(raw: string, site: { owner?: ElementRecord, scope: Arra
   ref.status = "unknown";
   ref.unknownSegmentIndex = 0;
   const inactiveHint = (<ScopeResolution>scopeRes).inactiveHint;
-  if (inactiveHint) ref.scopeHint = inactiveHint;
+  if (inactiveHint) {
+    ref.scopeHint = inactiveHint;
+    ref.hintReason = (<ScopeResolution>scopeRes).inactiveHintReason;
+    ref.hintName = (<ScopeResolution>scopeRes).inactiveHintName;
+  }
   // a bare name that exists in the enclosing template/matrix scope needs its prefix
   const panelFrame = findFrame<ScopeFramePanelDynamic>(site.scope || [], "panelDynamic");
   const matrixFrame = findFrame<ScopeFrameMatrixRow>(site.scope || [], "matrixRow");
   if (matrixFrame && matrixFrame.columns.has(root)) {
     ref.suggestion = index.settings.expressionVariables.row + "." + root;
     ref.scopeHint = "\"" + root + "\" is a column of this matrix - reference it as {" + ref.suggestion + "}.";
+    ref.hintReason = SurveyLintHintReasons.matrixColumn;
+    ref.hintName = root;
   } else if (panelFrame && panelFrame.templateNames.has(root)) {
     ref.suggestion = index.settings.expressionVariables.panel + "." + root;
     ref.scopeHint = "\"" + root + "\" is a question of this dynamic panel - reference it as {" + ref.suggestion + "}.";
+    ref.hintReason = SurveyLintHintReasons.panelQuestion;
+    ref.hintName = root;
   } else {
     const candidates = rootCandidates(index, options, nameOnly);
     let suggestion: string = undefined;
@@ -598,4 +621,42 @@ export function buildTriggerSetStep(trigger: TriggerRecord, operators?: { [op: s
   const root = splitRefSegments(match.variable.variable)[0];
   if (!root || !root.name || root.name.indexOf(":") > -1) return undefined;
   return { set: { [root.name]: (<Const>match.constSide).correctValue } };
+}
+
+export type ConditionSemanticsVerdict =
+  "alwaysFalse" | "alwaysTrue" | "notABoolean" | "meaninglessFragment";
+
+// The verdict the core's own semantic check gives a condition, refined into which defect it is.
+// Undefined when the core reports nothing, which keeps the linter at parity with
+// Base.validateExpressions - including its deliberate silence on a lone boolean constant, the one
+// form that is a switch the author meant rather than a defect.
+//
+// Only a condition is judged: a constant *expression* is legitimate (a calculated value of
+// "1 + 2"), a constant *condition* is not.
+export function getConditionSemanticsVerdict(site: ExpressionSite): ConditionSemanticsVerdict | undefined {
+  if (!site || site.kind !== "condition" || !!site.parseError || !site.ast) return undefined;
+  const ast = site.ast;
+  const errors: Array<any> = [];
+  ast.addConditionSemanticErrors(errors);
+  if (errors.length === 0) return undefined;
+  // A condition built only from constants has its result fixed at authoring time, so it can be
+  // evaluated without any answers: Const.evaluate() takes none, and the operands a constant tree
+  // is made of ignore the process value they are handed. A function call is never constant
+  // (FunctionOperand does not override isConstant), so nothing registered by the application runs
+  // here - hasFunction() states that intent rather than relying on it.
+  if (ast.isConstant() && !ast.hasFunction()) {
+    try {
+      return !!ast.evaluate() ? "alwaysTrue" : "alwaysFalse";
+    } catch{
+      return "meaninglessFragment";
+    }
+  }
+  // Knowing the value beats knowing the shape, so this runs after the branch above: a constant
+  // "1 + 1" is reported as alwaysTrue rather than as arithmetic. The core agrees - it adds the
+  // arithmetic error only when the operand is not constant.
+  const binary = <BinaryOperand>ast;
+  if (binary instanceof BinaryOperand && binary.isArithmetic && !binary.isConjunction) {
+    return "notABoolean";
+  }
+  return "meaninglessFragment";
 }

--- a/packages/survey-core/src/linter/index.ts
+++ b/packages/survey-core/src/linter/index.ts
@@ -5,6 +5,7 @@ import { buildIndex } from "./walker";
 import { LintMetadata } from "./metadata";
 
 export * from "./types";
+export * from "./reasons";
 export { renderFindings } from "./renderer";
 
 export function getRules(): Array<ILintRuleInfo> {

--- a/packages/survey-core/src/linter/reasons.ts
+++ b/packages/survey-core/src/linter/reasons.ts
@@ -1,0 +1,125 @@
+// The values below are public API: a host UI localizes on the (ruleId, reason) pair, the way the
+// Builder UI localizes on SurveyTestIssueCodes. Keep them stable - later work extends these
+// objects, it does not rename their members.
+
+// One entry per rule, listing every branch of that rule's message.
+export const SurveyLintReasons = Object.freeze({
+  "expression/syntax": Object.freeze({
+    unparsable: "unparsable",
+  }),
+  "reference/unknown": Object.freeze({
+    // no question, panel, page, calculated value or variable with that name
+    notFound: "notFound",
+    // the root resolved, a segment inside the container did not
+    inContainer: "inContainer",
+    // the name is not found inside the scope its prefix names
+    scopedUnknown: "scopedUnknown",
+  }),
+  "reference/self": Object.freeze({
+    selfReference: "selfReference",
+  }),
+  "name/duplicate": Object.freeze({
+    elementNames: "elementNames",
+    calculatedValueNames: "calculatedValueNames",
+    calculatedValueShadowsElement: "calculatedValueShadowsElement",
+  }),
+  "element/unknown-type": Object.freeze({
+    unknownType: "unknownType",
+  }),
+  "expression/unknown-function": Object.freeze({
+    notRegistered: "notRegistered",
+  }),
+  "cycle/calculated-value": Object.freeze({
+    self: "self",
+    loop: "loop",
+  }),
+  "cycle/trigger": Object.freeze({
+    self: "self",
+    loop: "loop",
+  }),
+  "expression/unknown-choice": Object.freeze({
+    // the operator compares by equality: the value is not among the choices
+    notAmongChoices: "notAmongChoices",
+    // the operator compares by substring: no choice value contains the value
+    noChoiceContains: "noChoiceContains",
+  }),
+  // these values already shipped inside messageData.reason
+  "expression/type-mismatch": Object.freeze({
+    "no-value": "no-value",
+    "non-scalar": "non-scalar",
+    "boolean-ordering": "boolean-ordering",
+    "text-ordering": "text-ordering",
+    "date-vs-number": "date-vs-number",
+    "number-vs-string": "number-vs-string",
+    "array-vs-scalar": "array-vs-scalar",
+    "boolean-vs-const": "boolean-vs-const",
+  }),
+  // today only the decidable part of "can never evaluate true": a condition built entirely from
+  // constants. Satisfiability reasoning extends this rule with its own reasons later.
+  "expression/contradiction": Object.freeze({
+    alwaysFalse: "alwaysFalse",
+  }),
+  "expression/meaningless-condition": Object.freeze({
+    alwaysTrue: "alwaysTrue",
+    // arithmetic at the root of a condition never produces a boolean
+    notABoolean: "notABoolean",
+    // a constant branch, a comparison of two constants, or an operand compared with itself
+    meaninglessFragment: "meaninglessFragment",
+  }),
+  // these values already shipped inside messageData.reason
+  "choices/dead-source": Object.freeze({
+    missing: "missing",
+    self: "self",
+    "not-a-source": "not-a-source",
+    "missing-field": "missing-field",
+  }),
+  "trigger/unknown-target": Object.freeze({
+    pageNotFound: "pageNotFound",
+    segmentNotFound: "segmentNotFound",
+    rootNotFound: "rootNotFound",
+  }),
+  "trigger/unknown-type": Object.freeze({
+    unknownType: "unknownType",
+    noType: "noType",
+  }),
+  "page/empty": Object.freeze({
+    emptyTemplate: "emptyTemplate",
+    noElements: "noElements",
+    noRenderableElements: "noRenderableElements",
+  }),
+});
+
+// The hint reference/unknown appends when a scoped prefix or a bare name is used outside the
+// container that would give it a meaning. Orthogonal to the reasons above: any base message of
+// reference/unknown can carry any of these.
+export const SurveyLintHintReasons = Object.freeze({
+  // "{name}." is only meaningful inside a matrix cell or a matrix detail panel
+  rowScopePrefix: "rowScopePrefix",
+  // "{name}" is only meaningful inside a matrix cell or a matrix detail panel
+  rowScopeStandalone: "rowScopeStandalone",
+  panelScopePrefix: "panelScopePrefix",
+  panelSiblingPrefix: "panelSiblingPrefix",
+  panelStandalone: "panelStandalone",
+  itemScope: "itemScope",
+  compositeScopePrefix: "compositeScopePrefix",
+  // the name exists in the surrounding container and only needs its prefix
+  matrixColumn: "matrixColumn",
+  panelQuestion: "panelQuestion",
+});
+
+// ILintReproduction.reason - what the steps demonstrate.
+export const SurveyLintReproductionReasons = Object.freeze({
+  selfReference: "selfReference",
+  calculatedValueCycle: "calculatedValueCycle",
+  triggerCycle: "triggerCycle",
+  noChoiceEquals: "noChoiceEquals",
+  noChoiceContains: "noChoiceContains",
+  missingTriggerTarget: "missingTriggerTarget",
+});
+
+// messageData.suggestionReason of expression/type-mismatch: the finding's own "suggestion" is
+// English prose, so a host that localizes needs the reason instead.
+export const SurveyLintSuggestionReasons = Object.freeze({
+  setNumberInputType: "setNumberInputType",
+  useContainsOrAnyof: "useContainsOrAnyof",
+});

--- a/packages/survey-core/src/linter/rule.ts
+++ b/packages/survey-core/src/linter/rule.ts
@@ -1,5 +1,5 @@
 import {
-  ILintFinding, ISurveyLintOptions, ISuppression, LintFindingSeverity, LintSeverity,
+  ILintFinding, ILintHint, ISurveyLintOptions, ISuppression, LintFindingSeverity, LintSeverity,
 } from "./types";
 import { SurveyIndex } from "./symbols";
 import { LintMetadata } from "./metadata";
@@ -45,7 +45,10 @@ export function isSuppressed(finding: ILintFinding, suppressions: Array<ISuppres
 export type ReportInput = {
   message: string,
   path: string,
+  // one of SurveyLintReasons[ruleId]
+  reason?: string,
   messageData?: { [key: string]: any },
+  hint?: ILintHint,
   elementName?: string,
   elementType?: string,
   suggestion?: string,
@@ -72,6 +75,8 @@ export class LintContext {
       messageData: input.messageData || {},
       path: input.path,
     };
+    if (input.reason) finding.reason = input.reason;
+    if (input.hint) finding.hint = input.hint;
     if (input.elementName) finding.elementName = input.elementName;
     if (input.elementType) finding.elementType = input.elementType;
     if (input.suggestion) finding.suggestion = input.suggestion;

--- a/packages/survey-core/src/linter/rules/choices-dead-source.ts
+++ b/packages/survey-core/src/linter/rules/choices-dead-source.ts
@@ -1,5 +1,8 @@
 import { Serializer } from "survey-core";
 import { closestMatch } from "../levenshtein";
+import { SurveyLintReasons } from "../reasons";
+
+const reasons = SurveyLintReasons["choices/dead-source"];
 import { ILintRule, LintContext } from "../rule";
 import { resolveCarryForwardSource } from "../expression-utils";
 import { CIMultiMap, ElementRecord } from "../symbols";
@@ -36,6 +39,7 @@ export const choicesDeadSourceRule: ILintRule = {
           message: "\"" + record.name + "\" copies its choices from \"" + sourceName +
             "\", but no question with that name exists.",
           path: path,
+          reason: reasons.missing,
           messageData: { name: record.name, source: sourceName, reason: "missing" },
           elementName: record.name,
           elementType: record.type,
@@ -47,6 +51,7 @@ export const choicesDeadSourceRule: ILintRule = {
         ctx.report({
           message: "\"" + record.name + "\" copies its choices from itself.",
           path: path,
+          reason: reasons.self,
           messageData: { name: record.name, source: sourceName, reason: "self" },
           elementName: record.name,
           elementType: record.type,
@@ -64,6 +69,7 @@ export const choicesDeadSourceRule: ILintRule = {
           message: "\"" + record.name + "\" copies its choices from \"" + sourceName + "\" (" + sourceType +
             "), which provides neither choices nor an array of values.",
           path: path,
+          reason: reasons["not-a-source"],
           messageData: { name: record.name, source: sourceName, sourceType: sourceType, reason: "not-a-source" },
           elementName: record.name,
           elementType: record.type,
@@ -82,7 +88,11 @@ export const choicesDeadSourceRule: ILintRule = {
               "\", but " + sourceType + " \"" + sourceName + "\" has no such " +
               (sourceType === "paneldynamic" ? "template question" : "column") + ".",
             path: fieldPath,
-            messageData: { name: record.name, source: sourceName, field: fieldValue, reason: "missing-field", prop: prop },
+            reason: reasons["missing-field"],
+            messageData: {
+              name: record.name, source: sourceName, sourceType: sourceType, field: fieldValue,
+              reason: "missing-field", prop: prop,
+            },
             elementName: record.name,
             elementType: record.type,
             suggestion: closestMatch(fieldValue, fields.names()),

--- a/packages/survey-core/src/linter/rules/cycle-calculated-value.ts
+++ b/packages/survey-core/src/linter/rules/cycle-calculated-value.ts
@@ -3,6 +3,9 @@ import { classifySiteRefs } from "../expression-utils";
 import { findCycles } from "../graph";
 import { CalculatedValueRecord, ParsedRef } from "../symbols";
 import { ILintReproduction } from "../types";
+import { SurveyLintReasons, SurveyLintReproductionReasons } from "../reasons";
+
+const reasons = SurveyLintReasons["cycle/calculated-value"];
 
 export const cycleCalculatedValueRule: ILintRule = {
   id: "cycle/calculated-value",
@@ -36,7 +39,8 @@ export const cycleCalculatedValueRule: ILintRule = {
       // null-proto: keys are user names, plain {} would swallow "__proto__"
       const expressions: { [name: string]: string } = Object.create(null);
       members.forEach(member => expressions[member.name] = member.expression || "");
-      const message = cycle.length === 1
+      const isSelf = cycle.length === 1;
+      const message = isSelf
         ? "The calculated value \"" + first.name + "\" references itself in its own expression."
         : "Calculated values " + cycle.map(name => "\"" + name + "\"").join(", ") + " depend on each other.";
       // an input the cycle depends on but does not itself compute, for the reproduction steps
@@ -52,6 +56,7 @@ export const cycleCalculatedValueRule: ILintRule = {
       });
       const reproduction: ILintReproduction = {
         description: "The cycle never settles: each value re-triggers the others. Expected to produce a finite value once the cycle is broken.",
+        reason: SurveyLintReproductionReasons.calculatedValueCycle,
         steps: [
           { set: { [externalRef || "<any input>"]: 1 } },
           { expect: { calculatedValue: { [first.name]: null } } },
@@ -60,7 +65,10 @@ export const cycleCalculatedValueRule: ILintRule = {
       ctx.report({
         message: message,
         path: first.site ? first.site.path : first.path,
-        messageData: { cycle: cycle.concat([cycle[0]]), expressions: expressions },
+        reason: isSelf ? reasons.self : reasons.loop,
+        // "cycle" is the closed loop: the first name appears again as the last element.
+        // "names" is the same loop without that repetition, which is what a message lists.
+        messageData: { cycle: cycle.concat([cycle[0]]), names: cycle.slice(), expressions: expressions },
         elementName: first.name,
         elementType: "calculatedvalue",
         related: members.map(member => ({

--- a/packages/survey-core/src/linter/rules/cycle-trigger.ts
+++ b/packages/survey-core/src/linter/rules/cycle-trigger.ts
@@ -2,6 +2,9 @@ import { ILintRule, LintContext } from "../rule";
 import { buildTriggerSetStep, classifySiteRefs } from "../expression-utils";
 import { TriggerRecord } from "../symbols";
 import { ILintReproduction } from "../types";
+import { SurveyLintReasons, SurveyLintReproductionReasons } from "../reasons";
+
+const reasons = SurveyLintReasons["cycle/trigger"];
 import { findCycles } from "../graph";
 
 // Triggers write and expressions read DATA keys: a question's name and its
@@ -52,16 +55,25 @@ export const cycleTriggerRule: ILintRule = {
       const setStep = buildTriggerSetStep(first);
       const reproduction: ILintReproduction = setStep ? {
         description: "This fires the first trigger; each trigger in the cycle sets a value the next one reacts to.",
+        reason: SurveyLintReproductionReasons.triggerCycle,
         steps: [setStep],
       } : undefined;
+      const isSelf = cycle.length === 1;
       ctx.report({
-        message: (cycle.length === 1
+        message: (isSelf
           ? "The trigger at " + first.path + " reacts to the value it sets itself (\"" + first.setToName + "\")."
           : "Triggers form a loop through the values they set: " + labels.join(" -> ") + ".") +
           " The loop may be unreachable if the trigger conditions never hold together - verify the expressions.",
         path: first.path,
+        reason: isSelf ? reasons.self : reasons.loop,
         messageData: {
+          // "cycle" holds the rendered labels the English message lists. "members" holds the
+          // same triggers unformatted, so a host can compose its own labels.
           cycle: labels,
+          members: members.map(member => ({
+            path: member.path, type: member.type, setToName: member.setToName,
+          })),
+          setToName: first.setToName,
           triggerIndexes: members.map(member => member.index),
           setRoots: members.map(member => member.setRoot),
         },

--- a/packages/survey-core/src/linter/rules/element-unknown-type.ts
+++ b/packages/survey-core/src/linter/rules/element-unknown-type.ts
@@ -1,5 +1,6 @@
 import { ILintRule, LintContext } from "../rule";
 import { closestMatch } from "../levenshtein";
+import { SurveyLintReasons } from "../reasons";
 
 export const elementUnknownTypeRule: ILintRule = {
   id: "element/unknown-type",
@@ -17,6 +18,7 @@ export const elementUnknownTypeRule: ILintRule = {
       ctx.report({
         message: message,
         path: record.path,
+        reason: SurveyLintReasons["element/unknown-type"].unknownType,
         messageData: { name: record.name, type: record.type },
         elementName: record.name,
         elementType: record.type,

--- a/packages/survey-core/src/linter/rules/expression-contradiction.ts
+++ b/packages/survey-core/src/linter/rules/expression-contradiction.ts
@@ -1,0 +1,30 @@
+import { ILintRule, LintContext } from "../rule";
+import { getConditionSemanticsVerdict } from "../expression-utils";
+import { SurveyLintReasons } from "../reasons";
+
+// The reachability group of the linter issue asks for "a condition parses but can never evaluate
+// true". Only the decidable part of that is implemented here - a condition built entirely from
+// constants, evaluated at lint time. Reasoning about satisfiability ("{q} = 'a' and {q} = 'b'")
+// extends this same rule later, with its own reason.
+export const expressionContradictionRule: ILintRule = {
+  id: "expression/contradiction",
+  defaultSeverity: "warning",
+  run(ctx: LintContext): void {
+    ctx.index.expressionSites.forEach(site => {
+      if (getConditionSemanticsVerdict(site) !== "alwaysFalse") return;
+      ctx.report({
+        message: "The " + site.prop + " \"" + site.text + "\" is built from constants only and is" +
+          " always false, so it never holds - the element it guards is never shown.",
+        path: site.path,
+        reason: SurveyLintReasons["expression/contradiction"].alwaysFalse,
+        messageData: {
+          expression: site.text,
+          prop: site.prop,
+          value: false,
+        },
+        elementName: site.owner ? site.owner.name : undefined,
+        elementType: site.owner ? site.owner.type : undefined,
+      });
+    });
+  },
+};

--- a/packages/survey-core/src/linter/rules/expression-meaningless-condition.ts
+++ b/packages/survey-core/src/linter/rules/expression-meaningless-condition.ts
@@ -1,0 +1,43 @@
+import { ILintRule, LintContext } from "../rule";
+import { getConditionSemanticsVerdict } from "../expression-utils";
+import { SurveyLintReasons } from "../reasons";
+
+const reasons = SurveyLintReasons["expression/meaningless-condition"];
+
+function getMessage(reason: string, prop: string, text: string): string {
+  if (reason === reasons.alwaysTrue) {
+    return "The " + prop + " \"" + text + "\" is built from constants only and is always true," +
+      " so it decides nothing - remove it.";
+  }
+  if (reason === reasons.notABoolean) {
+    return "The " + prop + " \"" + text + "\" is arithmetic, not a comparison, so it never" +
+      " produces a boolean result.";
+  }
+  return "A part of the " + prop + " \"" + text + "\" has a result known upfront - a constant" +
+    " branch, a comparison of two constants, or an operand compared with itself.";
+}
+
+// The semantic defects of a condition that the core's own check reports and that are not
+// contradictions: the result is known upfront, or the expression is not a condition at all.
+// Together with expression/contradiction this covers ExpressionErrorType.SemanticError, the one
+// type of Base.validateExpressions the linter did not report.
+export const expressionMeaninglessConditionRule: ILintRule = {
+  id: "expression/meaningless-condition",
+  defaultSeverity: "warning",
+  run(ctx: LintContext): void {
+    ctx.index.expressionSites.forEach(site => {
+      const verdict = getConditionSemanticsVerdict(site);
+      if (!verdict || verdict === "alwaysFalse") return;
+      const messageData: { [key: string]: any } = { expression: site.text, prop: site.prop };
+      if (verdict === reasons.alwaysTrue) messageData.value = true;
+      ctx.report({
+        message: getMessage(verdict, site.prop, site.text),
+        path: site.path,
+        reason: verdict,
+        messageData: messageData,
+        elementName: site.owner ? site.owner.name : undefined,
+        elementType: site.owner ? site.owner.type : undefined,
+      });
+    });
+  },
+};

--- a/packages/survey-core/src/linter/rules/expression-syntax.ts
+++ b/packages/survey-core/src/linter/rules/expression-syntax.ts
@@ -1,4 +1,5 @@
 import { ILintRule, LintContext } from "../rule";
+import { SurveyLintReasons } from "../reasons";
 
 export const expressionSyntaxRule: ILintRule = {
   id: "expression/syntax",
@@ -16,6 +17,7 @@ export const expressionSyntaxRule: ILintRule = {
       ctx.report({
         message: message,
         path: site.path,
+        reason: SurveyLintReasons["expression/syntax"].unparsable,
         messageData: {
           expression: site.text,
           at: at,

--- a/packages/survey-core/src/linter/rules/expression-type-mismatch.ts
+++ b/packages/survey-core/src/linter/rules/expression-type-mismatch.ts
@@ -1,5 +1,6 @@
 import { BinaryOperand, Const, Variable } from "survey-core";
 import { ILintRule, LintContext } from "../rule";
+import { SurveyLintSuggestionReasons } from "../reasons";
 import { classifySiteRefs, collectOperands, isPlainConst } from "../expression-utils";
 import { ElementRecord, ParsedRef } from "../symbols";
 import { isTextInputQuestion } from "../value-types";
@@ -14,6 +15,8 @@ interface Mismatch {
   reason: string;
   detail: string;
   suggestion?: string;
+  // one of SurveyLintSuggestionReasons - "suggestion" itself is prose, not an identifier
+  suggestionReason?: string;
 }
 
 function checkOrdering(record: ElementRecord, constValue: any): Mismatch | undefined {
@@ -36,6 +39,7 @@ function checkOrdering(record: ElementRecord, constValue: any): Mismatch | undef
       reason: "text-ordering",
       detail: "\"" + record.name + "\" is a text question - its value is a string, so numeric comparison relies on implicit conversion.",
       suggestion: "set inputType: \"number\" on \"" + record.name + "\" if it collects numbers",
+      suggestionReason: SurveyLintSuggestionReasons.setNumberInputType,
     };
   }
   if (valueType.scalarType === "date" && typeof constValue === "number") {
@@ -58,6 +62,7 @@ function checkEquality(record: ElementRecord, constValue: any): Mismatch | undef
       reason: "array-vs-scalar",
       detail: "\"" + record.name + "\" holds an array of selected values - \"=\" compares the whole array.",
       suggestion: "use \"contains\" or \"anyof\" for multi-select values",
+      suggestionReason: SurveyLintSuggestionReasons.useContainsOrAnyof,
     };
   }
   if (valueType.scalarType === "boolean" && typeof constValue !== "boolean" &&
@@ -124,14 +129,19 @@ export const expressionTypeMismatchRule: ILintRule = {
         ctx.report({
           message: message,
           path: site.path,
+          reason: mismatch.reason,
           messageData: {
             name: variable.variable,
+            // the detail sentences are about the element, and its name differs from the raw
+            // reference for valueName hits, "-Comment" keys, matrix "-total" keys and scoped refs
+            recordName: record.name,
             questionType: record.type,
             valueShape: record.valueType.shape,
             scalarType: record.valueType.scalarType,
             operator: op.operator,
             constValue: constValue,
             reason: mismatch.reason,
+            suggestionReason: mismatch.suggestionReason,
             expression: site.text,
           },
           elementName: site.owner ? site.owner.name : undefined,

--- a/packages/survey-core/src/linter/rules/expression-unknown-choice.ts
+++ b/packages/survey-core/src/linter/rules/expression-unknown-choice.ts
@@ -5,6 +5,9 @@ import { classifySiteRefs, collectOperands, getConstValues, matchVariableCompari
 import { ElementRecord, ParsedRef } from "../symbols";
 import { getSpecialChoiceValues } from "../value-types";
 import { ILintReproduction } from "../types";
+import { SurveyLintReasons, SurveyLintReproductionReasons } from "../reasons";
+
+const reasons = SurveyLintReasons["expression/unknown-choice"];
 import { ILintResolvedSettings } from "../lint-settings";
 
 const CHOICE_OPERATORS: { [op: string]: boolean } = {
@@ -92,6 +95,9 @@ export const expressionUnknownChoiceRule: ILintRule = {
           reproduction = {
             description: "No selectable choice of \"" + record.name + "\" " +
               (useSubstring ? "contains " : "equals ") + missingText + ".",
+            reason: useSubstring
+              ? SurveyLintReproductionReasons.noChoiceContains
+              : SurveyLintReproductionReasons.noChoiceEquals,
             steps: record.choicesInfo.staticValues.slice(0, 3).map(value => ({ set: { [record.name]: value } })),
           };
           reproduction.steps.push({ expect: { visible: { [site.owner.name]: true } } });
@@ -101,8 +107,10 @@ export const expressionUnknownChoiceRule: ILintRule = {
             (useSubstring ? " - no choice value contains it." : " - not among its choices.") +
             " Available: " + availableText + ". (in \"" + site.text + "\")",
           path: site.path,
+          reason: useSubstring ? reasons.noChoiceContains : reasons.notAmongChoices,
           messageData: {
             name: refName,
+            recordName: record.name,
             reference: ref.raw,
             operator: match.operator,
             values: missing,

--- a/packages/survey-core/src/linter/rules/expression-unknown-function.ts
+++ b/packages/survey-core/src/linter/rules/expression-unknown-function.ts
@@ -2,6 +2,7 @@ import { FunctionFactory } from "survey-core";
 import { ILintRule, LintContext } from "../rule";
 import { getFunctionOperands } from "../expression-utils";
 import { closestMatch } from "../levenshtein";
+import { SurveyLintReasons } from "../reasons";
 
 export const expressionUnknownFunctionRule: ILintRule = {
   id: "expression/unknown-function",
@@ -27,6 +28,7 @@ export const expressionUnknownFunctionRule: ILintRule = {
         ctx.report({
           message: message,
           path: site.path,
+          reason: SurveyLintReasons["expression/unknown-function"].notRegistered,
           messageData: { functionName: name, expression: site.text },
           elementName: site.owner ? site.owner.name : undefined,
           elementType: site.owner ? site.owner.type : undefined,

--- a/packages/survey-core/src/linter/rules/index.ts
+++ b/packages/survey-core/src/linter/rules/index.ts
@@ -12,6 +12,8 @@ import { expressionTypeMismatchRule } from "./expression-type-mismatch";
 import { choicesDeadSourceRule } from "./choices-dead-source";
 import { triggerUnknownTargetRule } from "./trigger-unknown-target";
 import { triggerUnknownTypeRule } from "./trigger-unknown-type";
+import { expressionContradictionRule } from "./expression-contradiction";
+import { expressionMeaninglessConditionRule } from "./expression-meaningless-condition";
 import { pageEmptyRule } from "./page-empty";
 
 export const allRules: Array<ILintRule> = [
@@ -25,6 +27,8 @@ export const allRules: Array<ILintRule> = [
   cycleTriggerRule,
   expressionUnknownChoiceRule,
   expressionTypeMismatchRule,
+  expressionContradictionRule,
+  expressionMeaninglessConditionRule,
   choicesDeadSourceRule,
   triggerUnknownTargetRule,
   triggerUnknownTypeRule,

--- a/packages/survey-core/src/linter/rules/name-duplicate.ts
+++ b/packages/survey-core/src/linter/rules/name-duplicate.ts
@@ -1,5 +1,8 @@
 import { ILintRule, LintContext } from "../rule";
 import { ILintRelated } from "../types";
+import { SurveyLintReasons } from "../reasons";
+
+const reasons = SurveyLintReasons["name/duplicate"];
 
 export const nameDuplicateRule: ILintRule = {
   id: "name/duplicate",
@@ -17,6 +20,7 @@ export const nameDuplicateRule: ILintRule = {
             message: "The name \"" + name + "\" is used by " + records.length + " elements" + scopeText +
               " (" + kinds.join(", ") + ") - element names must be unique.",
             path: rec.path,
+            reason: reasons.elementNames,
             messageData: { name: name, kinds: kinds, count: records.length, scope: namespace.label },
             elementName: rec.name,
             elementType: rec.type,
@@ -39,6 +43,7 @@ export const nameDuplicateRule: ILintRule = {
           ctx.report({
             message: "The calculated value name \"" + cv.name + "\" is already used by another calculated value.",
             path: path,
+            reason: reasons.calculatedValueNames,
             messageData: { name: cv.name, kinds: ["calculatedvalue", "calculatedvalue"], count: 2 },
             elementName: cv.name,
             elementType: "calculatedvalue",
@@ -53,6 +58,7 @@ export const nameDuplicateRule: ILintRule = {
             message: "The calculated value \"" + cv.name + "\" shares its name with a " + elements[0].kind +
               " - both are referenced as {" + cv.name + "}, so one of them shadows the other.",
             path: path,
+            reason: reasons.calculatedValueShadowsElement,
             messageData: { name: cv.name, kinds: ["calculatedvalue"].concat(elements.map(el => el.kind)), count: elements.length + 1 },
             elementName: cv.name,
             elementType: "calculatedvalue",

--- a/packages/survey-core/src/linter/rules/page-empty.ts
+++ b/packages/survey-core/src/linter/rules/page-empty.ts
@@ -1,9 +1,31 @@
 import { ILintRule, LintContext } from "../rule";
-import { ContainerRecord, ElementRecord } from "../symbols";
+import { ContainerRecord, ElementRecord, SurveyIndex } from "../symbols";
+import { getConditionSemanticsVerdict } from "../expression-utils";
+import { SurveyLintReasons } from "../reasons";
 
-// A question renders unless it is statically hidden (visible: false with no visibleIf).
-// html/image and custom/unknown types count as rendering. A panel renders when any child does.
-function buildRenderableCheck(containers: Array<ContainerRecord>): (el: ElementRecord) => boolean {
+const reasons = SurveyLintReasons["page/empty"];
+
+// The elements whose own visibleIf can never hold. Only "visibleIf" counts: choicesVisibleIf and
+// rowsVisibleIf hide items inside a question, and templateVisibleIf hides single panels of a
+// dynamic panel - none of them stops the question itself from rendering.
+function buildNeverVisibleSet(index: SurveyIndex): Set<ElementRecord> {
+  const res = new Set<ElementRecord>();
+  index.expressionSites.forEach(site => {
+    if (site.prop !== "visibleIf" || !site.owner) return;
+    if (getConditionSemanticsVerdict(site) === "alwaysFalse") res.add(site.owner);
+  });
+  return res;
+}
+
+// A question renders unless it is statically hidden (visible: false with no visibleIf) or its
+// visibleIf can never hold. html/image and custom/unknown types count as rendering. A panel
+// renders when any child does.
+//
+// The two tests are deliberately not symmetric for a panel: a panel with visible: false is not
+// renderable, but a panel with a dead visibleIf is, because expression/contradiction already
+// reports that condition and one defect should produce one finding.
+function buildRenderableCheck(containers: Array<ContainerRecord>,
+  neverVisible: Set<ElementRecord>): (el: ElementRecord) => boolean {
   const containerByRecord = new Map<ElementRecord, ContainerRecord>();
   containers.forEach(container => {
     if (container.record) containerByRecord.set(container.record, container);
@@ -15,7 +37,7 @@ function buildRenderableCheck(containers: Array<ContainerRecord>): (el: ElementR
       if (!container) return true;
       return container.children.some(isRenderable);
     }
-    return true;
+    return !neverVisible.has(el);
   };
   return isRenderable;
 }
@@ -24,7 +46,7 @@ export const pageEmptyRule: ILintRule = {
   id: "page/empty",
   defaultSeverity: "warning",
   run(ctx: LintContext): void {
-    const isRenderable = buildRenderableCheck(ctx.index.containers);
+    const isRenderable = buildRenderableCheck(ctx.index.containers, buildNeverVisibleSet(ctx.index));
     ctx.index.containers.forEach(container => {
       if (container.kind === "panelDynamicTemplate") {
         if (container.children.length === 0) {
@@ -32,6 +54,7 @@ export const pageEmptyRule: ILintRule = {
             message: "The dynamic panel \"" + (container.name || container.path) +
               "\" has an empty template - its panels have nothing to render.",
             path: container.path,
+            reason: reasons.emptyTemplate,
             messageData: { name: container.name, kind: "emptyTemplate" },
             elementName: container.name,
             elementType: "paneldynamic",
@@ -42,12 +65,15 @@ export const pageEmptyRule: ILintRule = {
       if (container.children.some(isRenderable)) return;
       const kind = container.kind;
       const label = container.name || container.path;
-      const reason = container.children.length === 0
+      const isEmpty = container.children.length === 0;
+      const reasonText = isEmpty
         ? "has no elements"
-        : "has no elements that can ever render (every element is statically hidden or empty)";
+        : "has no elements that can ever render (every element is statically hidden, never shown" +
+          " by its own condition, or empty)";
       ctx.report({
-        message: "The " + kind + " \"" + label + "\" " + reason + ".",
+        message: "The " + kind + " \"" + label + "\" " + reasonText + ".",
         path: container.path,
+        reason: isEmpty ? reasons.noElements : reasons.noRenderableElements,
         messageData: {
           name: container.name,
           kind: kind,

--- a/packages/survey-core/src/linter/rules/reference-self.ts
+++ b/packages/survey-core/src/linter/rules/reference-self.ts
@@ -3,6 +3,7 @@ import { classifySiteRefs, equalsCI } from "../expression-utils";
 import { ElementRecord, ExpressionSite, ParsedRef } from "../symbols";
 import { ILintReproduction } from "../types";
 import { ILintResolvedSettings } from "../lint-settings";
+import { SurveyLintReasons, SurveyLintReproductionReasons } from "../reasons";
 
 const SELF_PROPS: { [prop: string]: boolean } = { visibleIf: true, enableIf: true, requiredIf: true };
 
@@ -32,6 +33,7 @@ function buildReproduction(owner: ElementRecord, prop: string): ILintReproductio
   const res: ILintReproduction = {
     description: "Answering \"" + owner.name + "\" re-evaluates its own " + prop +
       "; if the element becomes hidden its value is cleared, which flips the condition again.",
+    reason: SurveyLintReproductionReasons.selfReference,
     steps: [{ set: { [owner.name]: "<any value>" } }],
   };
   if (prop === "visibleIf") {
@@ -55,6 +57,7 @@ export const referenceSelfRule: ILintRule = {
         message: "The " + site.prop + " of \"" + owner.name + "\" references the element itself ({" +
           selfRef.raw + "} in \"" + site.text + "\").",
         path: site.path,
+        reason: SurveyLintReasons["reference/self"].selfReference,
         messageData: {
           name: owner.name,
           prop: site.prop,

--- a/packages/survey-core/src/linter/rules/reference-unknown.ts
+++ b/packages/survey-core/src/linter/rules/reference-unknown.ts
@@ -1,18 +1,29 @@
 import { ILintRule, LintContext } from "../rule";
 import { classifyNameRef, classifySiteRefs } from "../expression-utils";
 import { ExpressionSite, NameRef, ParsedRef } from "../symbols";
+import { SurveyLintReasons } from "../reasons";
+import { ILintHint } from "../types";
+
+const reasons = SurveyLintReasons["reference/unknown"];
 
 function segmentName(ref: ParsedRef): string {
   const idx = ref.unknownSegmentIndex || 0;
   return ref.segments[idx] ? ref.segments[idx].name : ref.raw;
 }
 
-function buildMessage(ref: ParsedRef, context: string): string {
+function getReason(ref: ParsedRef): string {
   const idx = ref.unknownSegmentIndex || 0;
+  if (ref.status === "scoped-unknown") return reasons.scopedUnknown;
+  if (idx > 0 && ref.resolvedTo) return reasons.inContainer;
+  return reasons.notFound;
+}
+
+function buildMessage(ref: ParsedRef, context: string): string {
   let message: string;
-  if (ref.status === "scoped-unknown") {
+  const reason = getReason(ref);
+  if (reason === reasons.scopedUnknown) {
     message = "\"" + segmentName(ref) + "\" is not found in the \"" + ref.scopePrefix + "\" scope of {" + ref.raw + "}.";
-  } else if (idx > 0 && ref.resolvedTo) {
+  } else if (reason === reasons.inContainer) {
     message = "\"" + segmentName(ref) + "\" is not found in " + ref.resolvedTo.type + " \"" + ref.segments[0].name + "\" ({" + ref.raw + "}).";
   } else {
     message = "\"" + ref.raw + "\" is not found - no question, panel, page, calculated value, or variable with that name exists.";
@@ -23,15 +34,24 @@ function buildMessage(ref: ParsedRef, context: string): string {
   return message;
 }
 
+function getHint(ref: ParsedRef): ILintHint {
+  if (!ref.hintReason) return undefined;
+  return { reason: ref.hintReason, name: ref.hintName };
+}
+
 function reportRef(ctx: LintContext, ref: ParsedRef, path: string, site: ExpressionSite | undefined,
   expression: string, refKind: string): void {
   ctx.report({
     message: buildMessage(ref, expression ? "(in \"" + expression + "\")" : ""),
     path: path,
+    reason: getReason(ref),
+    hint: getHint(ref),
     messageData: {
       name: ref.raw,
       segment: segmentName(ref),
       segmentIndex: ref.unknownSegmentIndex || 0,
+      root: ref.segments[0].name,
+      containerType: ref.resolvedTo ? ref.resolvedTo.type : undefined,
       expression: expression,
       refKind: refKind,
       scopePrefix: ref.scopePrefix,
@@ -62,11 +82,16 @@ export const referenceUnknownRule: ILintRule = {
           message: buildMessage(ref, nameRef.kind === "binding"
             ? "(referenced in bindings)" : "(referenced in the choicesByUrl URL)"),
           path: nameRef.path,
+          reason: getReason(ref),
+          hint: getHint(ref),
           messageData: {
             name: ref.raw,
             segment: segmentName(ref),
             segmentIndex: ref.unknownSegmentIndex || 0,
+            root: ref.segments[0].name,
+            containerType: ref.resolvedTo ? ref.resolvedTo.type : undefined,
             refKind: nameRef.kind,
+            scopePrefix: ref.scopePrefix,
             note: "No case: the reference cannot be evaluated.",
           },
           elementName: nameRef.owner ? nameRef.owner.name : undefined,

--- a/packages/survey-core/src/linter/rules/trigger-unknown-target.ts
+++ b/packages/survey-core/src/linter/rules/trigger-unknown-target.ts
@@ -1,4 +1,7 @@
 import { closestMatch } from "../levenshtein";
+import { SurveyLintReasons, SurveyLintReproductionReasons } from "../reasons";
+
+const reasons = SurveyLintReasons["trigger/unknown-target"];
 import { ILintRule, LintContext } from "../rule";
 import { buildTriggerSetStep, builtInVariableNames, classifyTargetName, equalsCI } from "../expression-utils";
 import { ParsedRef, TriggerRecord } from "../symbols";
@@ -36,6 +39,7 @@ function buildReproduction(trigger: TriggerRecord, targetName: string): ILintRep
   if (!step) return undefined;
   return {
     description: "This fires the trigger, which then targets the missing element \"" + targetName + "\".",
+    reason: SurveyLintReproductionReasons.missingTriggerTarget,
     steps: [step],
   };
 }
@@ -83,6 +87,7 @@ export const triggerUnknownTargetRule: ILintRule = {
           ctx.report({
             message: "The " + trigger.type + " trigger targets page \"" + target.name + "\", which does not exist.",
             path: target.path,
+            reason: reasons.pageNotFound,
             messageData: messageData,
             suggestion: rootSuggestion(ctx, ref, "page"),
             reproduction: buildReproduction(trigger, target.name),
@@ -93,11 +98,15 @@ export const triggerUnknownTargetRule: ILintRule = {
         if (ref.unknownSegmentIndex > 0 && ref.resolvedTo) {
           const segment = ref.segments[ref.unknownSegmentIndex];
           messageData.segment = segment.name;
+          messageData.root = root;
+          messageData.containerType = ref.resolvedTo.type;
+          messageData.segmentIndex = ref.unknownSegmentIndex;
           ctx.report({
             message: "The " + trigger.type + " trigger targets \"" + target.name + "\", but " +
               ref.resolvedTo.type + " \"" + root + "\" has no " +
               innerNoun(ref.resolvedTo.type, ref.unknownSegmentIndex) + " \"" + segment.name + "\".",
             path: target.path,
+            reason: reasons.segmentNotFound,
             messageData: messageData,
             suggestion: ref.suggestion,
             reproduction: buildReproduction(trigger, target.name),
@@ -113,6 +122,7 @@ export const triggerUnknownTargetRule: ILintRule = {
               ? " If it is a variable set at runtime, list it in options.knownVariables."
               : ""),
           path: target.path,
+          reason: reasons.rootNotFound,
           messageData: messageData,
           suggestion: rootSuggestion(ctx, ref, target.kind),
           reproduction: buildReproduction(trigger, target.name),

--- a/packages/survey-core/src/linter/rules/trigger-unknown-type.ts
+++ b/packages/survey-core/src/linter/rules/trigger-unknown-type.ts
@@ -1,5 +1,8 @@
 import { ILintRule, LintContext } from "../rule";
 import { closestMatch } from "../levenshtein";
+import { SurveyLintReasons } from "../reasons";
+
+const reasons = SurveyLintReasons["trigger/unknown-type"];
 
 export const triggerUnknownTypeRule: ILintRule = {
   id: "trigger/unknown-type",
@@ -9,6 +12,7 @@ export const triggerUnknownTypeRule: ILintRule = {
     ctx.index.triggers.forEach(trigger => {
       if (!!ctx.metadata.getTriggerDef(trigger.type)) return;
       const suggestion = trigger.type ? closestMatch(trigger.type, knownTypes) : undefined;
+      const reason = trigger.type ? reasons.unknownType : reasons.noType;
       let message = trigger.type
         ? "The trigger type \"" + trigger.type + "\" is not known."
         : "The trigger has no type.";
@@ -18,6 +22,7 @@ export const triggerUnknownTypeRule: ILintRule = {
       ctx.report({
         message: message,
         path: trigger.path,
+        reason: reason,
         messageData: { type: trigger.type, known: knownTypes },
         elementType: "trigger",
         suggestion: suggestion,

--- a/packages/survey-core/src/linter/symbols.ts
+++ b/packages/survey-core/src/linter/symbols.ts
@@ -152,6 +152,9 @@ export interface ParsedRef {
   unknownSegmentIndex?: number;
   scopePrefix?: string;
   scopeHint?: string;
+  // the localizable form of scopeHint: one of SurveyLintHintReasons, plus the variable it is about
+  hintReason?: string;
+  hintName?: string;
   suggestion?: string;
 }
 

--- a/packages/survey-core/src/linter/types.ts
+++ b/packages/survey-core/src/linter/types.ts
@@ -31,6 +31,8 @@ export type LintReproductionStep = { set: { [name: string]: any } } | { expect: 
 
 export interface ILintReproduction {
   description?: string;
+  // one of SurveyLintReproductionReasons - the localizable form of "description"
+  reason?: string;
   steps: Array<LintReproductionStep>;
 }
 
@@ -39,11 +41,24 @@ export interface ILintRelated {
   elementName?: string;
 }
 
+export interface ILintHint {
+  // one of SurveyLintHintReasons
+  reason: string;
+  // the expression variable the hint is about, as configured in settings.expressionVariables
+  name: string;
+}
+
 export interface ILintFinding {
   ruleId: string;
   severity: LintFindingSeverity;
+  // ready to show to a human, in English
   message: string;
+  // one of SurveyLintReasons[ruleId] - which branch of the rule's message this is. A host that
+  // localizes composes its own sentence from (ruleId, reason) plus messageData.
+  reason?: string;
   messageData: { [key: string]: any };
+  // the scope hint appended to the message, when there is one. Independent of "reason".
+  hint?: ILintHint;
   path: string;
   elementName?: string;
   elementType?: string;

--- a/packages/survey-core/tests/linter/linter-condition-semantics.tests.ts
+++ b/packages/survey-core/tests/linter/linter-condition-semantics.tests.ts
@@ -1,0 +1,200 @@
+import { describe, test, expect } from "vitest";
+import { ConditionsParser, FunctionFactory } from "survey-core";
+import { lintSurvey, ILintFinding } from "../../src/linter/index";
+import { withFunction } from "./lint-test-helpers";
+
+function findingsOf(json: any, ruleId?: string): Array<ILintFinding> {
+  const all = lintSurvey(json).findings;
+  return ruleId ? all.filter(f => f.ruleId === ruleId) : all;
+}
+
+// One question guarded by the condition under test, plus a question the condition can refer to.
+function guardedBy(condition: string): any {
+  return {
+    elements: [
+      { type: "text", name: "q1" },
+      { type: "text", name: "q2", visibleIf: condition },
+    ],
+  };
+}
+
+function verdictOf(condition: string): { ruleId: string, reason: string } | undefined {
+  const findings = findingsOf(guardedBy(condition))
+    .filter(f => f.ruleId === "expression/contradiction" ||
+      f.ruleId === "expression/meaningless-condition");
+  if (findings.length === 0) return undefined;
+  expect(findings).toHaveLength(1);
+  return { ruleId: findings[0].ruleId, reason: findings[0].reason };
+}
+
+describe("the six forms the core reports as a semantic error", () => {
+  test("a condition built only from constants", () => {
+    expect(verdictOf("1 = 2")).toEqual(
+      { ruleId: "expression/contradiction", reason: "alwaysFalse" });
+    expect(verdictOf("1 = 1 and 2 = 3")).toEqual(
+      { ruleId: "expression/contradiction", reason: "alwaysFalse" });
+    expect(verdictOf("1 = 1")).toEqual(
+      { ruleId: "expression/meaningless-condition", reason: "alwaysTrue" });
+  });
+  test("arithmetic at the root of a condition", () => {
+    expect(verdictOf("{q1} + 1")).toEqual(
+      { ruleId: "expression/meaningless-condition", reason: "notABoolean" });
+  });
+  test("a constant branch of and/or", () => {
+    expect(verdictOf("{q1} = 1 or 2 = 2")).toEqual(
+      { ruleId: "expression/meaningless-condition", reason: "meaninglessFragment" });
+  });
+  test("a comparison of two constants inside a bigger condition", () => {
+    expect(verdictOf("{q1} = 1 and 2 = 3")).toEqual(
+      { ruleId: "expression/meaningless-condition", reason: "meaninglessFragment" });
+  });
+  test("an operand compared with itself", () => {
+    expect(verdictOf("{q1} = {q1}")).toEqual(
+      { ruleId: "expression/meaningless-condition", reason: "meaninglessFragment" });
+  });
+  test("a unary operator over a constant", () => {
+    // the whole condition is constant, so knowing its value beats knowing its shape
+    expect(verdictOf("'abc' notempty")).toEqual(
+      { ruleId: "expression/meaningless-condition", reason: "alwaysTrue" });
+  });
+});
+
+describe("classification of a fully constant condition", () => {
+  test("the value decides, not the shape", () => {
+    // constant arithmetic is reported by its value, not as notABoolean: the core agrees, it adds
+    // the arithmetic error only when the operand is not constant
+    expect(verdictOf("1 + 1")).toEqual(
+      { ruleId: "expression/meaningless-condition", reason: "alwaysTrue" });
+    expect(verdictOf("2 > 3")).toEqual(
+      { ruleId: "expression/contradiction", reason: "alwaysFalse" });
+    expect(verdictOf("'a' = 'b'")).toEqual(
+      { ruleId: "expression/contradiction", reason: "alwaysFalse" });
+    expect(verdictOf("''")).toEqual(
+      { ruleId: "expression/contradiction", reason: "alwaysFalse" });
+  });
+});
+
+describe("what stays clean", () => {
+  test("a lone boolean constant is a switch the author meant", () => {
+    expect(verdictOf("true")).toBeUndefined();
+    expect(verdictOf("false")).toBeUndefined();
+  });
+  test("a condition that depends on the data", () => {
+    expect(verdictOf("{q1} = 1")).toBeUndefined();
+    expect(verdictOf("{q1} = {q2}")).toBeUndefined();
+  });
+  test("a boolean question used as the whole condition", () => {
+    expect(verdictOf("{q1}")).toBeUndefined();
+  });
+  test("a value-producing expression may legitimately be constant", () => {
+    const findings = findingsOf({
+      elements: [{ type: "text", name: "q1" }],
+      calculatedValues: [{ name: "cv", expression: "1 + 2" }],
+    });
+    expect(findings.filter(f => f.ruleId === "expression/contradiction" ||
+      f.ruleId === "expression/meaningless-condition")).toHaveLength(0);
+  });
+  test("a syntactically broken condition is left to expression/syntax", () => {
+    const findings = findingsOf(guardedBy("{q1} ==="));
+    expect(findings.filter(f => f.ruleId === "expression/meaningless-condition")).toHaveLength(0);
+    expect(findings.filter(f => f.ruleId === "expression/syntax")).toHaveLength(1);
+  });
+});
+
+describe("no function is executed while linting", () => {
+  test("a call is never constant, so it is neither reported nor run", () => {
+    let calls = 0;
+    withFunction("probeFn", () => { calls++; return 1; }, () => {
+      expect(verdictOf("probeFn(1) = 2")).toBeUndefined();
+      expect(verdictOf("probeFn(1) = probeFn(1)")).toBeUndefined();
+    });
+    expect(calls).toBe(0);
+  });
+});
+
+describe("parity with the semantic check of the core", () => {
+  const expressions = [
+    "1 = 2", "1 = 1", "1 = 1 and 2 = 3", "'a' = 'b'", "2 > 3", "1 + 1", "''",
+    "'abc' notempty", "{q1} + 1", "{q1} = 1 or 2 = 2", "{q1} = 1 and 2 = 3", "{q1} = {q1}",
+    "true", "false", "{q1} = 1", "{q1}", "{q1} = {q2}", "{q1} notempty",
+  ];
+  test("the linter reports exactly what addConditionSemanticErrors reports", () => {
+    const mismatches: Array<string> = [];
+    expressions.forEach(expression => {
+      const ast = new ConditionsParser().parseExpression(expression);
+      const coreErrors: Array<any> = [];
+      if (!!ast) ast.addConditionSemanticErrors(coreErrors);
+      const coreReports = coreErrors.length > 0;
+      const linterReports = !!verdictOf(expression);
+      if (coreReports !== linterReports) {
+        mismatches.push(expression + ": core=" + coreReports + " linter=" + linterReports);
+      }
+    });
+    expect(mismatches).toEqual([]);
+  });
+});
+
+describe("how these rules sit next to the ones that read a variable against a constant", () => {
+  test("a condition with no variable-to-constant pair is reported by the new rules alone", () => {
+    ["1 = 2", "{q1} = {q1}"].forEach(condition => {
+      const findings = findingsOf(guardedBy(condition));
+      expect(findings.filter(f => f.ruleId === "expression/type-mismatch")).toHaveLength(0);
+      expect(findings.filter(f => f.ruleId === "expression/unknown-choice")).toHaveLength(0);
+    });
+  });
+  test("arithmetic over a text question is reported by both rules, about different things", () => {
+    // notABoolean is about the condition not producing a boolean at all; type-mismatch is about
+    // the text question being used in arithmetic. Both hold, and each rule can be switched off
+    // on its own, so neither suppresses the other.
+    const findings = findingsOf(guardedBy("{q1} + 1"));
+    expect(findings.filter(f => f.ruleId === "expression/meaningless-condition")
+      .map(f => f.reason)).toEqual(["notABoolean"]);
+    expect(findings.filter(f => f.ruleId === "expression/type-mismatch")
+      .map(f => f.messageData.reason)).toEqual(["text-ordering"]);
+  });
+  test("the overlap comes from the question type, not from the condition", () => {
+    const findings = findingsOf({
+      elements: [
+        { type: "text", name: "q1", inputType: "number" },
+        { type: "text", name: "q2", visibleIf: "{q1} + 1" },
+      ],
+    });
+    expect(findings.filter(f => f.ruleId === "expression/meaningless-condition")
+      .map(f => f.reason)).toEqual(["notABoolean"]);
+    expect(findings.filter(f => f.ruleId === "expression/type-mismatch")).toHaveLength(0);
+  });
+});
+
+describe("the conditions of every element kind are judged", () => {
+  test("enableIf, requiredIf and a trigger expression are conditions too", () => {
+    const findings = findingsOf({
+      elements: [
+        { type: "text", name: "q1", enableIf: "1 = 2" },
+        { type: "text", name: "q2", requiredIf: "1 = 1" },
+      ],
+      triggers: [{ type: "complete", expression: "2 > 3" }],
+    });
+    const byRule = (id: string) => findings.filter(f => f.ruleId === id).map(f => f.reason);
+    expect(byRule("expression/contradiction").sort()).toEqual(["alwaysFalse", "alwaysFalse"]);
+    expect(byRule("expression/meaningless-condition")).toEqual(["alwaysTrue"]);
+  });
+});
+
+describe("the finding carries what a host needs to compose its own message", () => {
+  test("expression, prop and the computed value", () => {
+    const findings = findingsOf(guardedBy("1 = 2"), "expression/contradiction");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].messageData.expression).toBe("1 = 2");
+    expect(findings[0].messageData.prop).toBe("visibleIf");
+    expect(findings[0].messageData.value).toBe(false);
+    expect(findings[0].elementName).toBe("q2");
+    expect(findings[0].severity).toBe("warning");
+    expect(findings[0].path).toBe("elements[1].visibleIf");
+  });
+  test("alwaysTrue reports the value too, the other reasons do not", () => {
+    const alwaysTrue = findingsOf(guardedBy("1 = 1"), "expression/meaningless-condition");
+    expect(alwaysTrue[0].messageData.value).toBe(true);
+    const fragment = findingsOf(guardedBy("{q1} = {q1}"), "expression/meaningless-condition");
+    expect(fragment[0].messageData.value).toBeUndefined();
+  });
+});

--- a/packages/survey-core/tests/linter/linter-reasons.tests.ts
+++ b/packages/survey-core/tests/linter/linter-reasons.tests.ts
@@ -1,0 +1,508 @@
+import { describe, test, expect } from "vitest";
+import {
+  getRules, lintSurvey, ILintFinding, SurveyLintHintReasons, SurveyLintReasons,
+  SurveyLintReproductionReasons,
+} from "../../src/linter/index";
+
+function findingsOf(json: any, ruleId: string): Array<ILintFinding> {
+  return lintSurvey(json).findings.filter(f => f.ruleId === ruleId);
+}
+
+// One fixture per (ruleId, reason): the table is only useful if every value in it is actually
+// produced by a rule, and every value a rule produces is in it.
+const CASES: Array<{ ruleId: string, reason: string, json: any }> = [
+  {
+    ruleId: "expression/syntax", reason: "unparsable",
+    json: { elements: [{ type: "text", name: "q1" }, { type: "text", name: "q2", visibleIf: "{q1} ===" }] },
+  },
+  {
+    ruleId: "reference/unknown", reason: "notFound",
+    json: { elements: [{ type: "text", name: "q1", visibleIf: "{nope} = 1" }] },
+  },
+  {
+    ruleId: "reference/unknown", reason: "inContainer",
+    json: {
+      elements: [
+        { type: "paneldynamic", name: "members", templateElements: [{ type: "text", name: "inner" }] },
+        { type: "text", name: "q2", visibleIf: "{members[0].nope} = 1" },
+      ],
+    },
+  },
+  {
+    ruleId: "reference/unknown", reason: "scopedUnknown",
+    json: {
+      elements: [{
+        type: "matrixdynamic", name: "m",
+        columns: [{ name: "col1" }, { name: "col2", visibleIf: "{row.nosuchcol} = 1" }],
+      }],
+    },
+  },
+  {
+    ruleId: "reference/self", reason: "selfReference",
+    json: { elements: [{ type: "text", name: "q1", visibleIf: "{q1} notempty" }] },
+  },
+  {
+    ruleId: "name/duplicate", reason: "elementNames",
+    json: { elements: [{ type: "text", name: "q1" }, { type: "text", name: "q1" }] },
+  },
+  {
+    ruleId: "name/duplicate", reason: "calculatedValueNames",
+    json: {
+      elements: [{ type: "text", name: "q1" }],
+      calculatedValues: [{ name: "cv", expression: "1" }, { name: "cv", expression: "2" }],
+    },
+  },
+  {
+    ruleId: "name/duplicate", reason: "calculatedValueShadowsElement",
+    json: {
+      elements: [{ type: "text", name: "q1" }],
+      calculatedValues: [{ name: "q1", expression: "1" }],
+    },
+  },
+  {
+    ruleId: "element/unknown-type", reason: "unknownType",
+    json: { elements: [{ type: "nosuchtype", name: "q1" }] },
+  },
+  {
+    ruleId: "expression/unknown-function", reason: "notRegistered",
+    json: {
+      elements: [
+        { type: "text", name: "q1" },
+        { type: "text", name: "q2", visibleIf: "nosuchfn() = 1" },
+      ],
+    },
+  },
+  {
+    ruleId: "cycle/calculated-value", reason: "self",
+    json: {
+      elements: [{ type: "text", name: "q1" }],
+      calculatedValues: [{ name: "cv", expression: "{cv} + 1" }],
+    },
+  },
+  {
+    ruleId: "cycle/calculated-value", reason: "loop",
+    json: {
+      elements: [{ type: "text", name: "q1" }],
+      calculatedValues: [
+        { name: "a", expression: "{b} + 1" },
+        { name: "b", expression: "{a} + 1" },
+      ],
+    },
+  },
+  {
+    ruleId: "cycle/trigger", reason: "self",
+    json: {
+      elements: [{ type: "text", name: "q1" }],
+      triggers: [{ type: "setvalue", expression: "{q1} notempty", setToName: "q1", setValue: 1 }],
+    },
+  },
+  {
+    ruleId: "cycle/trigger", reason: "loop",
+    json: {
+      elements: [{ type: "text", name: "q1" }, { type: "text", name: "q2" }],
+      triggers: [
+        { type: "setvalue", expression: "{q2} notempty", setToName: "q1", setValue: 1 },
+        { type: "setvalue", expression: "{q1} notempty", setToName: "q2", setValue: 1 },
+      ],
+    },
+  },
+  {
+    ruleId: "expression/unknown-choice", reason: "notAmongChoices",
+    json: {
+      elements: [
+        { type: "dropdown", name: "q1", choices: ["a", "b"] },
+        { type: "text", name: "q2", visibleIf: "{q1} = 'zzz'" },
+      ],
+    },
+  },
+  {
+    ruleId: "expression/unknown-choice", reason: "noChoiceContains",
+    json: {
+      elements: [
+        { type: "dropdown", name: "q1", choices: ["apple", "banana"] },
+        { type: "text", name: "q2", visibleIf: "{q1} contains 'zzz'" },
+      ],
+    },
+  },
+  {
+    ruleId: "expression/type-mismatch", reason: "no-value",
+    json: {
+      elements: [
+        { type: "html", name: "banner" },
+        { type: "text", name: "q2", visibleIf: "{banner} > 0" },
+      ],
+    },
+  },
+  {
+    ruleId: "expression/type-mismatch", reason: "non-scalar",
+    json: {
+      elements: [
+        { type: "checkbox", name: "tags", choices: ["a"] },
+        { type: "text", name: "q2", visibleIf: "{tags} > 3" },
+      ],
+    },
+  },
+  {
+    ruleId: "expression/type-mismatch", reason: "boolean-ordering",
+    json: {
+      elements: [
+        { type: "boolean", name: "q1" },
+        { type: "text", name: "q2", visibleIf: "{q1} > 0" },
+      ],
+    },
+  },
+  {
+    ruleId: "expression/type-mismatch", reason: "text-ordering",
+    json: {
+      elements: [
+        { type: "text", name: "q1" },
+        { type: "text", name: "q2", visibleIf: "{q1} > 3" },
+      ],
+    },
+  },
+  {
+    ruleId: "expression/type-mismatch", reason: "date-vs-number",
+    json: {
+      elements: [
+        { type: "text", name: "birth", inputType: "date" },
+        { type: "text", name: "q2", visibleIf: "{birth} < 2007" },
+      ],
+    },
+  },
+  {
+    ruleId: "expression/type-mismatch", reason: "number-vs-string",
+    json: {
+      elements: [
+        { type: "text", name: "age", inputType: "number" },
+        { type: "text", name: "q2", visibleIf: "{age} > 'ten'" },
+      ],
+    },
+  },
+  {
+    ruleId: "expression/type-mismatch", reason: "array-vs-scalar",
+    json: {
+      elements: [
+        { type: "checkbox", name: "tags", choices: ["a", "b"] },
+        { type: "text", name: "q2", visibleIf: "{tags} = 'a'" },
+      ],
+    },
+  },
+  {
+    ruleId: "expression/type-mismatch", reason: "boolean-vs-const",
+    json: {
+      elements: [
+        { type: "boolean", name: "agree" },
+        { type: "text", name: "q2", visibleIf: "{agree} = 'yes'" },
+      ],
+    },
+  },
+  {
+    ruleId: "expression/contradiction", reason: "alwaysFalse",
+    json: { elements: [{ type: "text", name: "q1", visibleIf: "1 = 2" }] },
+  },
+  {
+    ruleId: "expression/meaningless-condition", reason: "alwaysTrue",
+    json: { elements: [{ type: "text", name: "q1", visibleIf: "1 = 1" }] },
+  },
+  {
+    ruleId: "expression/meaningless-condition", reason: "notABoolean",
+    json: {
+      elements: [
+        { type: "text", name: "q1" },
+        { type: "text", name: "q2", visibleIf: "{q1} + 1" },
+      ],
+    },
+  },
+  {
+    ruleId: "expression/meaningless-condition", reason: "meaninglessFragment",
+    json: {
+      elements: [
+        { type: "text", name: "q1" },
+        { type: "text", name: "q2", visibleIf: "{q1} = 1 or 2 = 2" },
+      ],
+    },
+  },
+  {
+    ruleId: "choices/dead-source", reason: "missing",
+    json: { elements: [{ type: "dropdown", name: "q1", choicesFromQuestion: "nope" }] },
+  },
+  {
+    ruleId: "choices/dead-source", reason: "self",
+    json: { elements: [{ type: "dropdown", name: "q1", choicesFromQuestion: "q1" }] },
+  },
+  {
+    ruleId: "choices/dead-source", reason: "not-a-source",
+    json: {
+      elements: [
+        { type: "text", name: "src" },
+        { type: "dropdown", name: "q1", choicesFromQuestion: "src" },
+      ],
+    },
+  },
+  {
+    ruleId: "choices/dead-source", reason: "missing-field",
+    json: {
+      elements: [
+        { type: "matrixdynamic", name: "src", columns: [{ name: "col1" }] },
+        {
+          type: "dropdown", name: "q1", choicesFromQuestion: "src",
+          choiceValuesFromQuestion: "nosuchcol",
+        },
+      ],
+    },
+  },
+  {
+    ruleId: "trigger/unknown-target", reason: "pageNotFound",
+    json: {
+      pages: [{ name: "p1", elements: [{ type: "text", name: "q1" }] }],
+      triggers: [{ type: "visible", expression: "{q1} notempty", pages: ["nosuchpage"] }],
+    },
+  },
+  {
+    ruleId: "trigger/unknown-target", reason: "segmentNotFound",
+    json: {
+      elements: [
+        { type: "matrixdynamic", name: "m1", columns: [{ name: "col1" }] },
+        { type: "text", name: "src" },
+      ],
+      triggers: [{
+        type: "copyvalue", expression: "{src} notempty", setToName: "m1[0].col9", fromName: "src",
+      }],
+    },
+  },
+  {
+    ruleId: "trigger/unknown-target", reason: "rootNotFound",
+    json: {
+      elements: [{ type: "text", name: "q1" }],
+      triggers: [{ type: "setvalue", expression: "{q1} notempty", setToName: "nope", setValue: 1 }],
+    },
+  },
+  {
+    ruleId: "trigger/unknown-type", reason: "unknownType",
+    json: {
+      elements: [{ type: "text", name: "q1" }],
+      triggers: [{ type: "nosuchtrigger", expression: "{q1} notempty" }],
+    },
+  },
+  {
+    ruleId: "trigger/unknown-type", reason: "noType",
+    json: { elements: [{ type: "text", name: "q1" }], triggers: [{ expression: "{q1} notempty" }] },
+  },
+  {
+    ruleId: "page/empty", reason: "emptyTemplate",
+    json: { elements: [{ type: "paneldynamic", name: "pd", templateElements: [] }] },
+  },
+  {
+    ruleId: "page/empty", reason: "noElements",
+    json: { pages: [{ name: "p1", elements: [] }] },
+  },
+  {
+    ruleId: "page/empty", reason: "noRenderableElements",
+    json: { pages: [{ name: "p1", elements: [{ type: "text", name: "q1", visible: false }] }] },
+  },
+];
+
+describe("linter reasons - the (ruleId, reason) table", () => {
+  test("the table lists exactly the registered rules", () => {
+    expect(Object.keys(SurveyLintReasons).sort()).toEqual(getRules().map(r => r.id).sort());
+  });
+  test("every entry maps a key to itself, so a typo cannot go unnoticed", () => {
+    Object.keys(SurveyLintReasons).forEach(ruleId => {
+      const table = SurveyLintReasons[ruleId];
+      Object.keys(table).forEach(key => expect(table[key]).toBe(key));
+    });
+    Object.keys(SurveyLintHintReasons).forEach(key => {
+      expect(SurveyLintHintReasons[key]).toBe(key);
+    });
+    Object.keys(SurveyLintReproductionReasons).forEach(key => {
+      expect(SurveyLintReproductionReasons[key]).toBe(key);
+    });
+  });
+  test("the tables are frozen - the values are public API", () => {
+    expect(Object.isFrozen(SurveyLintReasons)).toBe(true);
+    expect(Object.isFrozen(SurveyLintHintReasons)).toBe(true);
+    Object.keys(SurveyLintReasons).forEach(ruleId => {
+      expect(Object.isFrozen(SurveyLintReasons[ruleId])).toBe(true);
+    });
+  });
+});
+
+describe("linter reasons - every reason is reachable", () => {
+  CASES.forEach(entry => {
+    test(entry.ruleId + " / " + entry.reason, () => {
+      const findings = findingsOf(entry.json, entry.ruleId);
+      expect(findings.length).toBeGreaterThan(0);
+      expect(findings.map(f => f.reason)).toContain(entry.reason);
+    });
+  });
+  test("the cases cover every value of the table", () => {
+    const covered: { [ruleId: string]: { [reason: string]: boolean } } = {};
+    CASES.forEach(entry => {
+      if (!covered[entry.ruleId]) covered[entry.ruleId] = {};
+      covered[entry.ruleId][entry.reason] = true;
+    });
+    const missing: Array<string> = [];
+    Object.keys(SurveyLintReasons).forEach(ruleId => {
+      Object.keys(SurveyLintReasons[ruleId]).forEach(reason => {
+        if (!covered[ruleId] || !covered[ruleId][reason]) missing.push(ruleId + "/" + reason);
+      });
+    });
+    expect(missing).toEqual([]);
+  });
+});
+
+describe("linter reasons - every finding carries one", () => {
+  test("no fixture produces a finding without a reason from its rule's table", () => {
+    const bad: Array<string> = [];
+    CASES.forEach(entry => {
+      lintSurvey(entry.json).findings.forEach(finding => {
+        const table = SurveyLintReasons[finding.ruleId];
+        if (!finding.reason || !table || !table[finding.reason]) {
+          bad.push(finding.ruleId + " -> " + finding.reason);
+        }
+      });
+    });
+    expect(bad).toEqual([]);
+  });
+  test("a reproduction, when present, carries a reason from its table", () => {
+    const bad: Array<string> = [];
+    CASES.forEach(entry => {
+      lintSurvey(entry.json).findings.forEach(finding => {
+        if (!finding.reproduction) return;
+        const reason = finding.reproduction.reason;
+        if (!reason || !SurveyLintReproductionReasons[reason]) {
+          bad.push(finding.ruleId + " -> " + reason);
+        }
+      });
+    });
+    expect(bad).toEqual([]);
+  });
+});
+
+describe("linter reasons - the scope hint", () => {
+  test("an inactive row scope reports the hint reason and the variable it is about", () => {
+    const findings = findingsOf({
+      elements: [{ type: "text", name: "q1", visibleIf: "{row.col1} = 1" }],
+    }, "reference/unknown");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].hint).toEqual({ reason: SurveyLintHintReasons.rowScopePrefix, name: "row" });
+    expect(findings[0].message).toContain("matrix cell");
+  });
+  test("an inactive panel scope reports the panelScopePrefix hint", () => {
+    const findings = findingsOf({
+      elements: [{ type: "text", name: "q1", visibleIf: "{panel.q} = 1" }],
+    }, "reference/unknown");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].hint.reason).toBe(SurveyLintHintReasons.panelScopePrefix);
+    expect(findings[0].message).toContain("dynamic panel");
+  });
+  test("a name that only needs its row prefix reports the matrixColumn hint", () => {
+    const findings = findingsOf({
+      elements: [{
+        type: "matrixdynamic", name: "m",
+        columns: [{ name: "col1" }, { name: "col2", visibleIf: "{col1} = 1" }],
+      }],
+    }, "reference/unknown");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].hint).toEqual({ reason: SurveyLintHintReasons.matrixColumn, name: "col1" });
+  });
+  test("a plain unresolved name carries no hint", () => {
+    const findings = findingsOf({
+      elements: [{ type: "text", name: "q1", visibleIf: "{nope} = 1" }],
+    }, "reference/unknown");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].hint).toBeUndefined();
+  });
+});
+
+describe("linter reasons - the data a localized message needs", () => {
+  test("reference/unknown inContainer reports the container type and the root name", () => {
+    const findings = findingsOf({
+      elements: [
+        { type: "paneldynamic", name: "members", templateElements: [{ type: "text", name: "inner" }] },
+        { type: "text", name: "q2", visibleIf: "{members[0].nope} = 1" },
+      ],
+    }, "reference/unknown");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].messageData.root).toBe("members");
+    expect(findings[0].messageData.containerType).toBe("paneldynamic");
+    expect(findings[0].message).toContain("paneldynamic");
+  });
+  test("choices/dead-source missing-field reports the source type", () => {
+    const findings = findingsOf({
+      elements: [
+        { type: "matrixdynamic", name: "src", columns: [{ name: "col1" }] },
+        {
+          type: "dropdown", name: "q1", choicesFromQuestion: "src",
+          choiceValuesFromQuestion: "nosuchcol",
+        },
+      ],
+    }, "choices/dead-source");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].messageData.sourceType).toBe("matrixdynamic");
+  });
+  test("trigger/unknown-target segmentNotFound reports what the noun depends on", () => {
+    const findings = findingsOf({
+      elements: [
+        { type: "matrixdynamic", name: "m1", columns: [{ name: "col1" }] },
+        { type: "text", name: "src" },
+      ],
+      triggers: [{
+        type: "copyvalue", expression: "{src} notempty", setToName: "m1[0].col9", fromName: "src",
+      }],
+    }, "trigger/unknown-target");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].messageData.containerType).toBe("matrixdynamic");
+    expect(findings[0].messageData.segmentIndex).toBe(1);
+    expect(findings[0].messageData.root).toBe("m1");
+    expect(findings[0].message).toContain("has no column");
+  });
+  test("expression/type-mismatch reports the element name the detail is about", () => {
+    const findings = findingsOf({
+      elements: [
+        { type: "text", name: "q1", valueName: "income" },
+        { type: "text", name: "q2", visibleIf: "{income} > 3" },
+      ],
+    }, "expression/type-mismatch");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].messageData.name).toBe("income");
+    expect(findings[0].messageData.recordName).toBe("q1");
+  });
+  test("expression/type-mismatch reports a reason for its prose suggestion", () => {
+    const findings = findingsOf({
+      elements: [
+        { type: "checkbox", name: "tags", choices: ["a", "b"] },
+        { type: "text", name: "q2", visibleIf: "{tags} = 'a'" },
+      ],
+    }, "expression/type-mismatch");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].messageData.suggestionReason).toBe("useContainsOrAnyof");
+  });
+  test("cycle/trigger reports the loop members unformatted", () => {
+    const findings = findingsOf({
+      elements: [{ type: "text", name: "q1" }, { type: "text", name: "q2" }],
+      triggers: [
+        { type: "setvalue", expression: "{q2} notempty", setToName: "q1", setValue: 1 },
+        { type: "setvalue", expression: "{q1} notempty", setToName: "q2", setValue: 1 },
+      ],
+    }, "cycle/trigger");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].messageData.members).toEqual([
+      { path: "triggers[0]", type: "setvalue", setToName: "q1" },
+      { path: "triggers[1]", type: "setvalue", setToName: "q2" },
+    ]);
+    expect(findings[0].messageData.setToName).toBe("q1");
+  });
+  test("cycle/calculated-value reports the loop without the repeated first name", () => {
+    const findings = findingsOf({
+      elements: [{ type: "text", name: "q1" }],
+      calculatedValues: [
+        { name: "a", expression: "{b} + 1" },
+        { name: "b", expression: "{a} + 1" },
+      ],
+    }, "cycle/calculated-value");
+    expect(findings).toHaveLength(1);
+    expect(findings[0].messageData.cycle).toEqual(["a", "b", "a"]);
+    expect(findings[0].messageData.names).toEqual(["a", "b"]);
+  });
+});

--- a/packages/survey-core/tests/linter/linter-structure.tests.ts
+++ b/packages/survey-core/tests/linter/linter-structure.tests.ts
@@ -47,6 +47,66 @@ describe("page/empty", () => {
       }],
     })).toHaveLength(0);
   });
+  test("an element whose visibleIf can never hold does not count as renderable", () => {
+    const findings = byRule({
+      pages: [{ name: "p1", elements: [{ type: "text", name: "q1", visibleIf: "1 = 2" }] }],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].reason).toBe("noRenderableElements");
+  });
+  test("one live element among dead ones keeps the page renderable", () => {
+    expect(byRule({
+      pages: [{
+        name: "p1",
+        elements: [
+          { type: "text", name: "q1", visibleIf: "1 = 2" },
+          { type: "text", name: "q2" },
+        ],
+      }],
+    })).toHaveLength(0);
+  });
+  test("a lone boolean constant is a deliberate switch and is not counted", () => {
+    // the core treats "false" as the one meaningful constant condition - an intentional way to
+    // hide an element - and the linter follows it here as well as in the condition rules
+    expect(byRule({
+      pages: [{ name: "p1", elements: [{ type: "text", name: "q1", visibleIf: "false" }] }],
+    })).toHaveLength(0);
+  });
+  test("a panel whose own visibleIf can never hold still counts as renderable", () => {
+    // expression/contradiction reports that condition, so page/empty stays out of it: one defect
+    // should produce one finding
+    expect(byRule({
+      pages: [{
+        name: "p1",
+        elements: [{
+          type: "panel", name: "pnl", visibleIf: "1 = 2",
+          elements: [{ type: "text", name: "q1" }],
+        }],
+      }],
+    })).toHaveLength(0);
+  });
+  test("a panel whose only child can never be shown is flagged with its page", () => {
+    const findings = byRule({
+      pages: [{
+        name: "p1",
+        elements: [{
+          type: "panel", name: "pnl",
+          elements: [{ type: "text", name: "q1", visibleIf: "1 = 2" }],
+        }],
+      }],
+    });
+    expect(findings.map(f => f.messageData.kind).sort()).toEqual(["page", "panel"]);
+  });
+  test("choicesVisibleIf does not make the question itself unrenderable", () => {
+    expect(byRule({
+      pages: [{
+        name: "p1",
+        elements: [{
+          type: "dropdown", name: "q1", choices: ["a", "b"], choicesVisibleIf: "1 = 2",
+        }],
+      }],
+    })).toHaveLength(0);
+  });
   test("empty paneldynamic template is flagged", () => {
     const findings = byRule({
       elements: [{ type: "paneldynamic", name: "p1", templateElements: [] }],


### PR DESCRIPTION
- Added new linting rules for detecting contradictions and meaningless conditions in expressions.
- Introduced comprehensive reasons for linter findings, ensuring better localization support.
- Implemented tests for new linter rules and reasons to ensure correctness and coverage.
- Updated existing tests to accommodate new validation logic and ensure consistency across the linter.