### PR TITLE
fix: clear non-existing Rating Scale values in clearIncorrectValues

### DIFF
--- a/packages/survey-core/src/question_rating.ts
+++ b/packages/survey-core/src/question_rating.ts
@@ -641,6 +641,12 @@ export class QuestionRatingModel extends Question implements IRatingItemOwner {
     }
     return !isNaN(val) ? parseFloat(val) : val;
   }
+  public clearIncorrectValues(): void {
+    if (this.isEmpty() || this.survey?.keepIncorrectValues) return;
+    if (!ItemValue.getItemByValue(this.visibleRateValues, this.value)) {
+      this.clearValue(true);
+    }
+  }
   public setValueFromClick(value: any) {
     if (this.isReadOnlyAttr) return;
     if (this.value === ((typeof (this.value) === "string") ? value : parseFloat(value))) {

--- a/packages/survey-core/tests/question_ratingtests.ts
+++ b/packages/survey-core/tests/question_ratingtests.ts
@@ -2227,3 +2227,100 @@ test("Test rateItem class on changing value, Bug#10737", () => {
   expect(containsSelected(item1), "item1 className after change select").toBe(false);
   expect(containsSelected(item2), "item2 className after change select").toBe(true);
 });
+test("clearIncorrectValues removes a value that is not in rateValues, Bug#11829", () => {
+  const survey = new SurveyModel({
+    pages: [
+      {
+        name: "page1",
+        elements: [
+          {
+            type: "radiogroup",
+            name: "question1",
+            choices: [
+              { value: "0", text: "" },
+              { value: "1", text: "" },
+              { value: "2", text: "" }
+            ]
+          },
+          {
+            type: "rating",
+            name: "satisfaction-numeric",
+            title: "How satisfied are you with our product?",
+            description: "Numeric rating scale",
+            autoGenerate: false,
+            rateCount: 10,
+            rateValues: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+          }
+        ]
+      }
+    ]
+  });
+  survey.data = {
+    "question1": "11",
+    "satisfaction-numeric": 11
+  };
+  expect(survey.data).toEqual({
+    "question1": "11",
+    "satisfaction-numeric": 11
+  });
+  survey.clearIncorrectValues();
+  expect(survey.data, "non-existing rating value is cleared").toEqual({});
+});
+test("clearIncorrectValues keeps an existing rating value", () => {
+  const survey = new SurveyModel({
+    elements: [
+      {
+        type: "rating",
+        name: "q1",
+        autoGenerate: false,
+        rateValues: [1, 2, 3, 4, 5]
+      }
+    ]
+  });
+  const q1 = <QuestionRatingModel>survey.getQuestionByName("q1");
+  q1.value = 5;
+  q1.clearIncorrectValues();
+  expect(q1.value, "existing rate value is kept").toBe(5);
+  q1.value = 11;
+  q1.clearIncorrectValues();
+  expect(q1.isEmpty(), "non-existing rate value is cleared").toBeTruthy();
+});
+test("clearIncorrectValues for auto-generated rate values", () => {
+  const survey = new SurveyModel({
+    elements: [
+      {
+        type: "rating",
+        name: "q1",
+        rateMin: 1,
+        rateMax: 5
+      }
+    ]
+  });
+  const q1 = <QuestionRatingModel>survey.getQuestionByName("q1");
+  q1.value = 3;
+  q1.clearIncorrectValues();
+  expect(q1.value, "value in generated range is kept").toBe(3);
+  q1.value = 11;
+  q1.clearIncorrectValues();
+  expect(q1.isEmpty(), "value outside generated range is cleared").toBeTruthy();
+});
+test("clearIncorrectValues respects survey.keepIncorrectValues", () => {
+  const survey = new SurveyModel({
+    elements: [
+      {
+        type: "rating",
+        name: "q1",
+        autoGenerate: false,
+        rateValues: [1, 2, 3]
+      }
+    ]
+  });
+  const q1 = <QuestionRatingModel>survey.getQuestionByName("q1");
+  survey.keepIncorrectValues = true;
+  q1.value = 11;
+  survey.clearIncorrectValues();
+  expect(q1.value, "incorrect value is kept").toBe(11);
+  survey.keepIncorrectValues = false;
+  survey.clearIncorrectValues();
+  expect(q1.isEmpty(), "incorrect value is cleared").toBeTruthy();
+});


### PR DESCRIPTION
Rating questions skipped the select-base cleanup path, so answers outside rateValues stayed in survey data.