### PR TITLE
fix: preserve inherited font weights in HTML content

### DIFF
--- a/e2e/questions/html.spec.ts
+++ b/e2e/questions/html.spec.ts
@@ -53,6 +53,12 @@ frameworks.forEach((framework) => {
       await page.keyboard.press("Tab");
       await expect(page.locator("span").filter({ hasText: "John" })).toBeVisible();
     });
+  });
+
+  test.describe(`${framework} HTML font inheritance`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(`${url}${framework}`);
+    });
 
     [false, true].forEach((completedPage) => {
       test(`HTML font inheritance ${completedPage ? "completed page" : "question"}`, async ({ page }) => {

--- a/e2e/questions/html.spec.ts
+++ b/e2e/questions/html.spec.ts
@@ -1,4 +1,4 @@
-import { frameworks, url, setOptions, initSurvey, test, expect } from "../helper";
+import { frameworks, url, setOptions, initSurvey, test, expect, getButtonByText } from "../helper";
 
 const title = "html question";
 
@@ -52,6 +52,31 @@ frameworks.forEach((framework) => {
       await page.locator("input[type=text]").fill("John");
       await page.keyboard.press("Tab");
       await expect(page.locator("span").filter({ hasText: "John" })).toBeVisible();
+    });
+
+    [false, true].forEach((completedPage) => {
+      test(`HTML font inheritance ${completedPage ? "completed page" : "question"}`, async ({ page }) => {
+        const html = "<div style='font-weight:700'>" +
+          "<span id='inherit-span'>Span</span><div id='inherit-div'>Div</div>" +
+          "<p id='inherit-p'>Paragraph</p>" +
+          "<table><tbody><tr><td id='inherit-td'>Cell</td></tr></tbody></table>" +
+          "<span id='override-weight' style='font-weight:300'>Override</span></div>" +
+          "<h2 id='heading-parent'><span id='heading-child'>Heading</span></h2>" +
+          "<p id='default-weight'>Default paragraph</p>";
+        await initSurvey(page, framework, {
+          elements: [{ type: "html", name: "inheritance", html }],
+          completedHtml: html
+        });
+        if (completedPage) {
+          await getButtonByText(page, "Complete").click();
+        }
+        for (const tag of ["span", "div", "p", "td"]) {
+          await expect(page.locator(`#inherit-${tag}`)).toHaveCSS("font-weight", "700");
+        }
+        await expect(page.locator("#override-weight")).toHaveCSS("font-weight", "300");
+        await expect(page.locator("#default-weight")).toHaveCSS("font-weight", "400");
+        await expect(page.locator("#heading-child")).toHaveCSS("font-weight", "700");
+      });
     });
   });
 });

--- a/packages/survey-core/src/default-theme/mixins.scss
+++ b/packages/survey-core/src/default-theme/mixins.scss
@@ -94,6 +94,7 @@
   div,
   p {
     @include articleDefaultFont;
+    font-weight: inherit;
   }
 
   a {


### PR DESCRIPTION
Fixes #10339.

An HTML question such as `<div style="font-weight:700"><span>Text</span></div>` renders the nested text at weight 400: `articleHtml` reapplies `articleDefaultFont` to every `td`, `span`, `div`, and `p`.

Let those descendants inherit their font weight after applying the existing typography defaults. This preserves ancestor weights and inline child overrides without changing the other font-size, spacing, or typography rules. The shared stylesheet applies the correction across renderers and to completed pages.

Add shared Playwright tests for HTML questions and completed pages, covering nested spans/divs/paragraphs/table cells, spans inside headings, ordinary text, and explicit child overrides. Both new tests fail with the original CSS (`400` instead of `700`) and pass with this change.

Validation on Node 24 / Windows:

- Core and React builds pass, including the core icon/i18n/theme prerequisites.
- React HTML-question E2E: all 5 tests pass, including both new regressions.
- React accessibility suite: all 38 tests pass.
- Full repository lint with zero warnings and `git diff --check` pass.
- Before the CSS change, baseline core tests passed (6,517 passed, 14 skipped) and React unit/markup tests passed (254). No JavaScript runtime implementation changed.
- Three existing visual checks (`Check html question`, wrapping, and `HTML default color`) fail against repository reference images. Rebuilt unchanged upstream CSS and reran them: the same three fail, and their produced PNGs are byte-for-byte identical with and without this patch. Reference images were not updated.

Browser checks used the repository's React harness with Chromium's supported new headless mode (`channel: 'chromium'`). The new tests are shared across framework runs; Angular/Vue runs and the full E2E/visual matrix were not executed locally.

Prepared with OpenAI Codex assistance and verified locally.


### CI follow-up

The initial Preact Shadow DOM E2E job exposed duplicate survey initialization in the new tests: the enclosing `beforeEach` attached a shadow root before the test called `initSurvey` again. The font-inheritance tests now have a separate setup that navigates to the page and initializes the survey once. All font assertions are retained.

Validated the revised file locally against both React and Preact Shadow DOM: all five HTML tests pass in each renderer. Preact build and changed-file lint also pass. Logs from the initial CI job showed these two setup errors and 466 passing tests; this update does not claim the complete hosted matrix has passed.
